### PR TITLE
Use secp256k1 instead of elliptic for better speed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const SHA3 = require('sha3')
-const ec = require('elliptic').ec('secp256k1')
+const secp256k1 = require('secp256k1')
 const assert = require('assert')
 const rlp = require('rlp')
 const BN = require('bn.js')
@@ -259,11 +259,8 @@ exports.pubToAddress = exports.publicToAddress = function (pubKey) {
  */
 var privateToPublic = exports.privateToPublic = function (privateKey) {
   privateKey = exports.toBuffer(privateKey)
-  if (privateKey.length !== 32)
-      throw new Error('invalid private key length')
-  privateKey = new BN(privateKey)
-  var key = ec.keyFromPrivate(privateKey).getPublic().toJSON()
-  return Buffer.concat([exports.pad(key[0], 32), exports.pad(key[1], 32)])
+  // skip the type flag and use the X, Y points
+  return secp256k1.publicKeyConvert(secp256k1.publicKeyCreate(privateKey), false).slice(1)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "bn.js": "^4.4.0",
     "browserify-sha3": "^0.0.1",
-    "elliptic": "^6.0.2",
     "rlp": "^2.0.0",
+    "secp256k1": "^2.0.7",
     "sha3": "^1.1.0"
   },
   "browser": {


### PR DESCRIPTION
On Node this should result in a >11-fold improvement:
> elliptic#pubkey x 535 ops/sec ±12.26% (9 runs sampled)
> secp256k1#pubkey x 7,922 ops/sec ±11.20% (8 runs sampled)

In the browser there shouldn't be any significant noticeable difference.