### PR TITLE
Removing excessive secp256k1.publicKeyConvert

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ exports.pubToAddress = exports.publicToAddress = function (pubKey, sanitize) {
 var privateToPublic = exports.privateToPublic = function (privateKey) {
   privateKey = exports.toBuffer(privateKey)
   // skip the type flag and use the X, Y points
-  return secp256k1.publicKeyConvert(secp256k1.publicKeyCreate(privateKey), false).slice(1)
+  return secp256k1.publicKeyCreate(privateKey, false).slice(1)
 }
 
 /**


### PR DESCRIPTION
secp256k1-node v3 has option `compressed` for `publicKeyCreate`
https://github.com/cryptocoinjs/secp256k1-node/blob/2e3ee65a90d294343001e8b03bcf146ba9332ddb/API.md#publickeycreatebuffer-privatekey--boolean-compressed--true---buffer