### PR TITLE
Feature - eth_sign signature method (different from tx sig)

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,7 @@ exports.ecsign = function (msgHash, privateKey) {
   var ret = {}
   ret.r = sig.signature.slice(0, 32)
   ret.s = sig.signature.slice(32, 64)
-  ret.v = sig.recovery + 27
+  ret.v = sig.recovery
   return ret
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -442,7 +442,7 @@ describe('ecsign', function () {
     var sig = ethUtils.ecsign(echash, ecprivkey)
     assert.deepEqual(sig.r, new Buffer('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex'))
     assert.deepEqual(sig.s, new Buffer('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex'))
-    assert.equal(sig.v, 27)
+    assert.equal(sig.v, 0)
   })
 })
 


### PR DESCRIPTION
As described in ethereumjs/testrpc#103 and ethereumjs/testrpc#104, the `v` value returned for `ecsign` is inconsistent between Geth and testrpc nodes. In Geth, `v` is always `00` or `01`. In testrpc, `v` is always `1a`  (27) or `1b` (28). As a result, any dapps which use `ecsign` will have inconsistent signature values between the two nodes. Note that Geth should probably the "authority" for this.

I'm not sure whether this patch should be included in this repository or in testrpc. I feel like it should be included in testrpc because it has the potential to break less repositories than ethereumjs-util. Still, I'm making a pull request here for posterity.

close ethereumjs/testrpc#104

cc @tcoulter 