### PR TITLE
changed pub key validation to sanitize when the key length is not 64 or explicitly requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ exports.isValidPublic = function (publicKey, sanitize) {
  */
 exports.pubToAddress = exports.publicToAddress = function (pubKey, sanitize) {
   pubKey = exports.toBuffer(pubKey)
-  if (sanitize && (pubKey.length !== 64)) {
+  if (sanitize || (pubKey.length !== 64)) {
     pubKey = secp256k1.publicKeyConvert(pubKey, false).slice(1)
   }
   assert(pubKey.length === 64)


### PR DESCRIPTION
@axic is this safe behavor? Do we need to `assert` after the sanitization? 