### PR TITLE
Update wrong variable name sha3() method

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -373,7 +373,7 @@ Creates SHA-3 hash of the input
 **Parameters**
 
 -   `a` **Buffer or Array or String or Number** the input data
--   `bytes` **[Number]** the SHA width (optional, default `256`)
+-   `bits` **[Number]** the SHA width (optional, default `256`)
 
 Returns **Buffer** 
 

--- a/index.js
+++ b/index.js
@@ -243,14 +243,14 @@ exports.toUnsigned = function (num) {
  * Creates SHA-3 hash of the input
  * @method sha3
  * @param {Buffer|Array|String|Number} a the input data
- * @param {Number} [bytes=256] the SHA width
+ * @param {Number} [bits=256] the SHA width
  * @return {Buffer}
  */
-exports.sha3 = function (a, bytes) {
+exports.sha3 = function (a, bits) {
   a = exports.toBuffer(a)
-  if (!bytes) bytes = 256
+  if (!bits) bits = 256
 
-  var h = new SHA3(bytes)
+  var h = new SHA3(bits)
   if (a) {
     h.update(a)
   }


### PR DESCRIPTION
```javascript
/**
 * Creates SHA-3 hash of the input
 * @method sha3
 * @param {Buffer|Array|String|Number} a the input data
 * @param {Number} [bytes=256] the SHA width
 * @return {Buffer}
 */
exports.sha3 = function (a, bytes) {
  a = exports.toBuffer(a)
  if (!bytes) bytes = 256

  var h = new SHA3(bytes)
  if (a) {
    h.update(a)
  }
  return new Buffer(h.digest('hex'), 'hex')
}
```
I don't think that is bytes.