### PR TITLE
Remove zero padding in intToHex

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ exports.intToHex = function (i) {
  */
 exports.intToBuffer = function (i) {
   var hex = exports.intToHex(i)
-  return Buffer.from(hex.slice(2), 'hex')
+  return Buffer.from(exports.padToEven(hex.slice(2)), 'hex')
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -170,9 +170,6 @@ exports.intToHex = function (i) {
   assert(i % 1 === 0, 'number is not a integer')
   assert(i >= 0, 'number must be positive')
   var hex = i.toString(16)
-  if (hex.length % 2) {
-    hex = '0' + hex
-  }
 
   return '0x' + hex
 }


### PR DESCRIPTION
The padded zeros when the value contains an uneven amount of digits causes a discrepency between how testrpc works, and how a true ethereum network works (e.g, the real ethereum network would return 0x1 for eth_getTransactionCount, whereas testrpc will return 0x01.)  

For quantities, testrpc behavior is against the [json rpc specification](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding) 