### PR TITLE
Name field is mandatory in npm >3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       "additions": 26,
       "deletions": 2
     },
-    {
+    { 
+      "name":"Mr. Chico"
       "url": "https://github.com/MrChico",
       "contributions": 1,
       "additions": 11,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "deletions": 2
     },
     { 
-      "name":"Mr. Chico"
+      "name":"Mr. Chico",
       "url": "https://github.com/MrChico",
       "contributions": 1,
       "additions": 11,


### PR DESCRIPTION
The name field is needed on all contributors in npm >3. Install fails without this fix.