### PR TITLE
Add helpers for new eth_sign behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,7 +367,7 @@ exports.ecsign = function (msgHash, privateKey) {
  * @param message
  * @returns {Buffer} hash
  */
-exports.hashForEthSign = function (message) {
+exports.hashPersonalMessage = function (message) {
   var prefix = exports.toBuffer('\u0019Ethereum Signed Message:\n' + message.length.toString())
   return exports.sha3(Buffer.concat([prefix, message]))
 }

--- a/index.js
+++ b/index.js
@@ -373,19 +373,6 @@ exports.hashPersonalMessage = function (message) {
 }
 
 /**
- * ECDSA sign `message` using the same algorithm as the `eth_sign` RPC method.
- * Prefixes message with fixed header + `message.length.toString()`, then
- * signs the Keccak256 hash of the result.
- * @param {Buffer} message
- * @param {Buffer} privateKey
- * @return {Object} signature
- */
-exports.ethSign = function (message, privateKey) {
-  var msgHash = exports.hashForEthSign(message)
-  return exports.ecsign(msgHash, privateKey)
-}
-
-/**
  * ECDSA public key recovery from signature
  * @param {Buffer} msgHash
  * @param {Number} v
@@ -401,19 +388,6 @@ exports.ecrecover = function (msgHash, v, r, s) {
   }
   var senderPubKey = secp256k1.recover(msgHash, signature, recovery)
   return secp256k1.publicKeyConvert(senderPubKey, false).slice(1)
-}
-
-/**
- * ECDSA public key recovery from a message signed with the `eth_sign` RPC call.
- * @param {Buffer} message
- * @param {Number} v
- * @param {Buffer} r
- * @param {Buffer} s
- * @returns {Buffer} publicKey
- */
-exports.ethRecover = function (message, v, r, s) {
-  var msgHash = exports.hashForEthSign(message)
-  return exports.ecrecover(msgHash, v, r, s)
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -479,9 +479,9 @@ describe('ecrecover', function () {
   })
 })
 
-describe('hashForEthSign', function () {
+describe('hashPersonalMessage', function () {
   it('should produce a deterministic hash', function () {
-    var h = ethUtils.hashForEthSign(Buffer.from('Hello world'))
+    var h = ethUtils.hashPersonalMessage(Buffer.from('Hello world'))
     assert.deepEqual(h, Buffer.from('8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede', 'hex'))
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -479,6 +479,31 @@ describe('ecrecover', function () {
   })
 })
 
+describe('hashForEthSign', function () {
+  it('should produce a deterministic hash', function () {
+    var h = ethUtils.hashForEthSign(Buffer.from('Hello world'))
+    assert.deepEqual(h, Buffer.from('8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede', 'hex'))
+  })
+})
+
+describe('ethSign', function () {
+  it('should produce a signature', function () {
+    var sig = ethUtils.ethSign(Buffer.from('Hello world'), ecprivkey)
+    assert.deepEqual(sig.r, Buffer.from('157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87', 'hex'))
+    assert.deepEqual(sig.s, Buffer.from('28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78', 'hex'))
+    assert.equal(sig.v, 27)
+  })
+})
+
+describe('ethRecover', function () {
+  it('should recover a public key', function () {
+    var r = Buffer.from('157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87', 'hex')
+    var s = Buffer.from('28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78', 'hex')
+    var pubkey = ethUtils.ethRecover(Buffer.from('Hello world'), 27, r, s)
+    assert.deepEqual(pubkey, ethUtils.privateToPublic(ecprivkey))
+  })
+})
+
 describe('isValidSignature', function () {
   it('should fail on an invalid signature (shorter r))', function () {
     var r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1ab', 'hex')

--- a/test/index.js
+++ b/test/index.js
@@ -486,24 +486,6 @@ describe('hashPersonalMessage', function () {
   })
 })
 
-describe('ethSign', function () {
-  it('should produce a signature', function () {
-    var sig = ethUtils.ethSign(Buffer.from('Hello world'), ecprivkey)
-    assert.deepEqual(sig.r, Buffer.from('157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87', 'hex'))
-    assert.deepEqual(sig.s, Buffer.from('28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78', 'hex'))
-    assert.equal(sig.v, 27)
-  })
-})
-
-describe('ethRecover', function () {
-  it('should recover a public key', function () {
-    var r = Buffer.from('157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87', 'hex')
-    var s = Buffer.from('28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78', 'hex')
-    var pubkey = ethUtils.ethRecover(Buffer.from('Hello world'), 27, r, s)
-    assert.deepEqual(pubkey, ethUtils.privateToPublic(ecprivkey))
-  })
-})
-
 describe('isValidSignature', function () {
   it('should fail on an invalid signature (shorter r))', function () {
     var r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1ab', 'hex')


### PR DESCRIPTION
This adds some helpers to deal with the recent changes to the `eth_sign` RPC call, as discussed in https://github.com/ethereumjs/testrpc/pull/244

The `hashForEthSign` function returns the prefixed and hashed input to the `ecsign` method for a given message, and is used by the `ethSign` function to produce a signature that matches the `eth_sign` output for a message.

There's also an `ethRecover` function, which just runs `ecrecover` on the output of `hashForEthSign`.

I'm not crazy about these function names, so feel free to suggest alternatives :)