### PR TITLE
Change browser from Chrome to ChromeHeadless

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,9 @@ module.exports = function (config) {
         if (process.env.TRAVIS) {
           return ['Firefox']
         }
+        if (availableBrowser.includes('Chrome')) {
+          return ['ChromeHeadless']
+        }
 
         var browsers = ['Chrome', 'Firefox']
         return browsers.filter(function (browser) {


### PR DESCRIPTION
Changing the browser from Chrome to ChromeHeadless

As when using chromium binary to launch chrome then getting issues
```
16 10 2018 07:27:28.210:ERROR [launcher]: Cannot start Chrome

16 10 2018 07:27:28.211:ERROR [launcher]: Chrome stdout:
16 10 2018 07:27:28.211:ERROR [launcher]: Chrome stderr:
16 10 2018 07:27:28.211:INFO [launcher]: Trying to start Chrome again (1/2).

16 10 2018 07:27:28.756:ERROR [launcher]: Cannot start Chrome

16 10 2018 07:27:28.757:ERROR [launcher]: Chrome stdout:
16 10 2018 07:27:28.757:ERROR [launcher]: Chrome stderr:
16 10 2018 07:27:28.768:INFO [launcher]: Trying to start Chrome again (2/2).
16 10 2018 07:27:29.292:ERROR [launcher]: Cannot start Chrome

16 10 2018 07:27:29.293:ERROR [launcher]: Chrome stdout:
16 10 2018 07:27:29.293:ERROR [launcher]: Chrome stderr:
16 10 2018 07:27:29.300:ERROR [launcher]: Chrome failed 2 times (cannot start). Giving up.
```
But, if using chromeHeadless in place of Chrome then the browser launches

Headless browsers provide automated control of a web page in an environment similar to popular web browsers, but are executed via a command-line interface or using network communication

Signed-off-by: ossdev <ossdev@puresoftware.com>