### PR TITLE
Pin ethjs-util version exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "bn.js": "^4.11.0",
     "create-hash": "^1.1.2",
-    "ethjs-util": "^0.1.6",
+    "ethjs-util": "0.1.6",
     "keccak": "^1.0.2",
     "rlp": "^2.0.0",
     "safe-buffer": "^5.1.1",


### PR DESCRIPTION
This PR pins the version of ethjs-util as a dependency exactly.

The important context for this PR is line 8:

https://github.com/ethereumjs/ethereumjs-util/blob/ff7bb865f5dd2750cd3b59f496a6681ec432b578/index.js#L8

As-is, we're depending on a 0.x _range_ which, according to semver, allows breaking changes while we're on a non-zero major version. `^0.1.6` (with the caret) allows ethjs-util to change underneath ethereumjs-util (e.g. if/when `0.1.7` is published) and introduce breaking changes to both their API and ethereumjs-util's API. Pinning the version allows us to only update when it's safe to do so.