### PR TITLE
Fix broken links in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@
 
 **● KECCAK256_NULL**: *`Buffer`* =  Buffer.from(KECCAK256_NULL_S, 'hex')
 
-*Defined in [index.ts:42](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L42)*
+*Defined in [index.ts:42](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L42)*
 
 Keccak-256 hash of null
 
@@ -82,7 +82,7 @@ ___
 
 **● KECCAK256_NULL_S**: *`string`* = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
 
-*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L36)*
+*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L36)*
 
 Keccak-256 hash of null
 
@@ -93,7 +93,7 @@ ___
 
 **● KECCAK256_RLP**: *`Buffer`* =  Buffer.from(KECCAK256_RLP_S, 'hex')
 
-*Defined in [index.ts:64](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L64)*
+*Defined in [index.ts:64](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L64)*
 
 Keccak-256 hash of the RLP of null
 
@@ -104,7 +104,7 @@ ___
 
 **● KECCAK256_RLP_ARRAY**: *`Buffer`* =  Buffer.from(KECCAK256_RLP_ARRAY_S, 'hex')
 
-*Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L53)*
+*Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L53)*
 
 Keccak-256 of an RLP of an empty array
 
@@ -115,7 +115,7 @@ ___
 
 **● KECCAK256_RLP_ARRAY_S**: *`string`* = "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
 
-*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L47)*
+*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L47)*
 
 Keccak-256 of an RLP of an empty array
 
@@ -126,7 +126,7 @@ ___
 
 **● KECCAK256_RLP_S**: *`string`* = "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
 
-*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L58)*
+*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L58)*
 
 Keccak-256 hash of the RLP of null
 
@@ -140,7 +140,7 @@ ___
   16,
 )
 
-*Defined in [index.ts:20](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L20)*
+*Defined in [index.ts:20](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L20)*
 
 The max integer that this VM can handle
 
@@ -154,7 +154,7 @@ ___
   16,
 )
 
-*Defined in [index.ts:28](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L28)*
+*Defined in [index.ts:28](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L28)*
 
 2^256
 
@@ -165,7 +165,7 @@ ___
 
 **● publicToAddress**: *[pubToAddress]()* =  pubToAddress
 
-*Defined in [index.ts:315](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L315)*
+*Defined in [index.ts:315](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L315)*
 
 ___
 <a id="setlength"></a>
@@ -174,7 +174,7 @@ ___
 
 **● setLength**: *[setLengthLeft]()* =  setLengthLeft
 
-*Defined in [index.ts:123](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L123)*
+*Defined in [index.ts:123](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L123)*
 
 ___
 <a id="stripzeros"></a>
@@ -183,7 +183,7 @@ ___
 
 **● stripZeros**: *[unpad]()* =  unpad
 
-*Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L150)*
+*Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L150)*
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 ▸ **addHexPrefix**(str: *`string`*): `string`
 
-*Defined in [index.ts:532](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L532)*
+*Defined in [index.ts:532](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L532)*
 
 Adds "0x" to a given `String` if it does not already start with "0x".
 
@@ -214,7 +214,7 @@ ___
 
 ▸ **baToJSON**(ba: *`any`*): `undefined` | `string` | `any`[]
 
-*Defined in [index.ts:584](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L584)*
+*Defined in [index.ts:584](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L584)*
 
 Converts a `Buffer` or `Array` to JSON.
 
@@ -234,7 +234,7 @@ ___
 
 ▸ **bufferToHex**(buf: *`Buffer`*): `string`
 
-*Defined in [index.ts:195](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L195)*
+*Defined in [index.ts:195](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L195)*
 
 Converts a `Buffer` into a hex `String`.
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **bufferToInt**(buf: *`Buffer`*): `number`
 
-*Defined in [index.ts:187](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L187)*
+*Defined in [index.ts:187](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L187)*
 
 Converts a `Buffer` to a `Number`.
 
@@ -272,7 +272,7 @@ ___
 
 ▸ **defineProperties**(self: *`any`*, fields: *`any`*, data: *`any`*): `void`
 
-*Defined in [index.ts:606](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L606)*
+*Defined in [index.ts:606](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L606)*
 
 Defines properties on a `Object`. It make the assumption that underlying data is binary.
 
@@ -293,7 +293,7 @@ ___
 
 ▸ **ecrecover**(msgHash: *`Buffer`*, v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, chainId?: *`undefined` | `number`*): `Buffer`
 
-*Defined in [index.ts:373](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L373)*
+*Defined in [index.ts:373](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L373)*
 
 ECDSA public key recovery from signature.
 
@@ -317,7 +317,7 @@ ___
 
 ▸ **ecsign**(msgHash: *`Buffer`*, privateKey: *`Buffer`*, chainId?: *`undefined` | `number`*): [ECDSASignature](interfaces/ecdsasignature.md)
 
-*Defined in [index.ts:341](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L341)*
+*Defined in [index.ts:341](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L341)*
 
 Returns the ECDSA signature of a message hash.
 
@@ -338,7 +338,7 @@ ___
 
 ▸ **fromRpcSig**(sig: *`string`*): [ECDSASignature](interfaces/ecdsasignature.md)
 
-*Defined in [index.ts:407](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L407)*
+*Defined in [index.ts:407](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L407)*
 
 Convert signature format of the `eth_sign` RPC method to signature parameters NOTE: all because of a bug in geth: [https://github.com/ethereum/go-ethereum/issues/2053](https://github.com/ethereum/go-ethereum/issues/2053)
 
@@ -357,7 +357,7 @@ ___
 
 ▸ **fromSigned**(num: *`Buffer`*): `BN`
 
-*Defined in [index.ts:204](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L204)*
+*Defined in [index.ts:204](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L204)*
 
 Interprets a `Buffer` as a signed integer and returns a `BN`. Assumes 256-bit numbers.
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **generateAddress**(from: *`Buffer`*, nonce: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:482](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L482)*
+*Defined in [index.ts:482](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L482)*
 
 Generates an address of a newly created contract.
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **generateAddress2**(from: *`Buffer` | `string`*, salt: *`Buffer` | `string`*, initCode: *`Buffer` | `string`*): `Buffer`
 
-*Defined in [index.ts:502](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L502)*
+*Defined in [index.ts:502](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L502)*
 
 Generates an address for a contract created using CREATE2.
 
@@ -417,7 +417,7 @@ ___
 
 ▸ **hashPersonalMessage**(message: *`any`*): `Buffer`
 
-*Defined in [index.ts:364](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L364)*
+*Defined in [index.ts:364](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L364)*
 
 Returns the keccak-256 hash of `message`, prefixed with the header used by the `eth_sign` RPC call. The output of this function can be fed into `ecsign` to produce the same signature as the `eth_sign` call for a given `message`, or fed to `ecrecover` along with a signature to recover the public key used to produce the signature.
 
@@ -436,7 +436,7 @@ ___
 
 ▸ **importPublic**(publicKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:330](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L330)*
+*Defined in [index.ts:330](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L330)*
 
 Converts a public key to the Ethereum format.
 
@@ -455,7 +455,7 @@ ___
 
 ▸ **isPrecompiled**(address: *`Buffer` | `string`*): `boolean`
 
-*Defined in [index.ts:524](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L524)*
+*Defined in [index.ts:524](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L524)*
 
 Returns true if the supplied address belongs to a precompiled account (Byzantium).
 
@@ -474,7 +474,7 @@ ___
 
 ▸ **isValidAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:439](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L439)*
+*Defined in [index.ts:439](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L439)*
 
 Checks if the address is a valid. Accepts checksummed addresses too.
 
@@ -493,7 +493,7 @@ ___
 
 ▸ **isValidChecksumAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:473](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L473)*
+*Defined in [index.ts:473](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L473)*
 
 Checks if the address is a valid checksummed address.
 
@@ -512,7 +512,7 @@ ___
 
 ▸ **isValidPrivate**(privateKey: *`Buffer`*): `boolean`
 
-*Defined in [index.ts:277](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L277)*
+*Defined in [index.ts:277](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L277)*
 
 Checks if the private key satisfies the rules of the curve secp256k1.
 
@@ -531,7 +531,7 @@ ___
 
 ▸ **isValidPublic**(publicKey: *`Buffer`*, sanitize?: *`boolean`*): `boolean`
 
-*Defined in [index.ts:287](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L287)*
+*Defined in [index.ts:287](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L287)*
 
 Checks if the public key satisfies the rules of the curve secp256k1 and the requirements of Ethereum.
 
@@ -551,7 +551,7 @@ ___
 
 ▸ **isValidSignature**(v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, homesteadOrLater?: *`boolean`*, chainId?: *`undefined` | `number`*): `boolean`
 
-*Defined in [index.ts:544](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L544)*
+*Defined in [index.ts:544](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L544)*
 
 Validate a ECDSA signature.
 
@@ -574,7 +574,7 @@ ___
 
 ▸ **isZeroAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:446](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L446)*
+*Defined in [index.ts:446](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L446)*
 
 Checks if a given address is a zero address.
 
@@ -593,7 +593,7 @@ ___
 
 ▸ **keccak**(a: *`any`*, bits?: *`number`*): `Buffer`
 
-*Defined in [index.ts:221](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L221)*
+*Defined in [index.ts:221](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L221)*
 
 Creates Keccak hash of the input
 
@@ -613,7 +613,7 @@ ___
 
 ▸ **keccak256**(a: *`any`*): `Buffer`
 
-*Defined in [index.ts:234](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L234)*
+*Defined in [index.ts:234](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L234)*
 
 Creates Keccak-256 hash of the input, alias for keccak(a, 256).
 
@@ -632,7 +632,7 @@ ___
 
 ▸ **privateToAddress**(privateKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:432](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L432)*
+*Defined in [index.ts:432](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L432)*
 
 Returns the ethereum address of a given private key.
 
@@ -651,7 +651,7 @@ ___
 
 ▸ **privateToPublic**(privateKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:321](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L321)*
+*Defined in [index.ts:321](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L321)*
 
 Returns the ethereum public key of a given private key.
 
@@ -670,7 +670,7 @@ ___
 
 ▸ **pubToAddress**(pubKey: *`Buffer`*, sanitize?: *`boolean`*): `Buffer`
 
-*Defined in [index.ts:306](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L306)*
+*Defined in [index.ts:306](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L306)*
 
 Returns the ethereum address of a given public key. Accepts "Ethereum public keys" and SEC1 encoded keys.
 
@@ -690,7 +690,7 @@ ___
 
 ▸ **ripemd160**(a: *`any`*, padded: *`boolean`*): `Buffer`
 
-*Defined in [index.ts:254](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L254)*
+*Defined in [index.ts:254](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L254)*
 
 Creates RIPEMD160 hash of the input.
 
@@ -710,7 +710,7 @@ ___
 
 ▸ **rlphash**(a: *`rlp.Input`*): `Buffer`
 
-*Defined in [index.ts:270](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L270)*
+*Defined in [index.ts:270](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L270)*
 
 Creates SHA-3 hash of the RLP encoded version of the input.
 
@@ -729,7 +729,7 @@ ___
 
 ▸ **setLengthLeft**(msg: *`any`*, length: *`number`*, right?: *`boolean`*): `any`
 
-*Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L106)*
+*Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L106)*
 
 Left Pads an `Array` or `Buffer` with leading zeros till it has `length` bytes. Or it truncates the beginning if it exceeds.
 
@@ -751,7 +751,7 @@ ___
 
 ▸ **setLengthRight**(msg: *`any`*, length: *`number`*): `any`
 
-*Defined in [index.ts:132](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L132)*
+*Defined in [index.ts:132](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L132)*
 
 Right Pads an `Array` or `Buffer` with leading zeros till it has `length` bytes. Or it truncates the beginning if it exceeds.
 
@@ -772,7 +772,7 @@ ___
 
 ▸ **sha256**(a: *`any`*): `Buffer`
 
-*Defined in [index.ts:242](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L242)*
+*Defined in [index.ts:242](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L242)*
 
 Creates SHA256 hash of the input.
 
@@ -791,7 +791,7 @@ ___
 
 ▸ **toBuffer**(v: *`any`*): `Buffer`
 
-*Defined in [index.ts:156](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L156)*
+*Defined in [index.ts:156](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L156)*
 
 Attempts to turn a value into a `Buffer`. As input it supports `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` method.
 
@@ -810,7 +810,7 @@ ___
 
 ▸ **toChecksumAddress**(address: *`string`*): `string`
 
-*Defined in [index.ts:454](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L454)*
+*Defined in [index.ts:454](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L454)*
 
 Returns a checksummed address.
 
@@ -829,7 +829,7 @@ ___
 
 ▸ **toRpcSig**(v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, chainId?: *`undefined` | `number`*): `string`
 
-*Defined in [index.ts:393](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L393)*
+*Defined in [index.ts:393](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L393)*
 
 Convert signature parameters into the format of `eth_sign` RPC method.
 
@@ -852,7 +852,7 @@ ___
 
 ▸ **toUnsigned**(num: *`BN`*): `Buffer`
 
-*Defined in [index.ts:212](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L212)*
+*Defined in [index.ts:212](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L212)*
 
 Converts a `BN` to an unsigned integer and returns it as a `Buffer`. Assumes 256-bit numbers.
 
@@ -871,7 +871,7 @@ ___
 
 ▸ **unpad**(a: *`any`*): `any`
 
-*Defined in [index.ts:141](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L141)*
+*Defined in [index.ts:141](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L141)*
 
 Trims leading zeros from a `Buffer` or an `Array`.
 
@@ -891,7 +891,7 @@ ___
 
 ▸ **zeroAddress**(): `string`
 
-*Defined in [index.ts:92](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L92)*
+*Defined in [index.ts:92](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L92)*
 
 Returns a zero address.
 
@@ -904,7 +904,7 @@ ___
 
 ▸ **zeros**(bytes: *`number`*): `Buffer`
 
-*Defined in [index.ts:85](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L85)*
+*Defined in [index.ts:85](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L85)*
 
 Returns a buffer filled with 0s.
 

--- a/docs/interfaces/ecdsasignature.md
+++ b/docs/interfaces/ecdsasignature.md
@@ -24,7 +24,7 @@
 
 **● r**: *`Buffer`*
 
-*Defined in [index.ts:13](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L13)*
+*Defined in [index.ts:13](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L13)*
 
 ___
 <a id="s"></a>
@@ -33,7 +33,7 @@ ___
 
 **● s**: *`Buffer`*
 
-*Defined in [index.ts:14](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L14)*
+*Defined in [index.ts:14](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L14)*
 
 ___
 <a id="v"></a>
@@ -42,7 +42,7 @@ ___
 
 **● v**: *`number`*
 
-*Defined in [index.ts:12](https://github.com/ethereumjs/ethereumjs-util/blob/dd56e02/src/index.ts#L12)*
+*Defined in [index.ts:12](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L12)*
 
 ___
 


### PR DESCRIPTION
According to README.md the link should lead to the `master` blob. But in the /docs/ folder, the README.md links lead to an old and unreachable URL (404; in blob `dd56e02` in of `master`).

This PR fix this.
Thanks for your time and the library 💯 