### PR TITLE
Update rlp to v2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "create-hash": "^1.1.2",
     "ethjs-util": "0.1.6",
     "keccak": "^1.0.2",
-    "rlp": "^2.0.0",
+    "rlp": "^2.2.3",
     "secp256k1": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
[rlphash](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L60) uses `RLP.Input` as its parameter type which was introduced in [v2.2.1](https://github.com/ethereumjs/rlp/releases/tag/v2.2.1). However in `package.json` the [dependency](https://github.com/ethereumjs/ethereumjs-util/blob/master/package.json#L90) is set to `v2.0.0`. Typescript libraries importing `ethereumjs-util` will get an error for this.