### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Additionally ethereumjs-util re-exports a few commonly-used libraries. These inc
 - `rlp` ([rlp](https://github.com/ethereumjs/rlp))
 - `secp256k1` ([secp256k1](https://github.com/cryptocoinjs/secp256k1-node/))
 
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).
+
 # LICENSE
 
 MPL-2.0

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "tslint": "ethereumjs-config-tslint",
     "tslint:fix": "ethereumjs-config-tslint-fix"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ethereumjs/ethereumjs-util.git"
@@ -102,6 +107,7 @@
     "browserify": "^14.0.0",
     "contributor": "^0.1.25",
     "coveralls": "^3.0.0",
+    "husky": "^2.1.0",
     "istanbul": "^0.4.1",
     "karma": "^4.0.0",
     "karma-browserify": "^5.0.0",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.