### PR TITLE
toBuffer now throws if strings aren't 0x-prefixed hex values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 ### App ###
 
 .cachedb

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ ___
 
 **● publicToAddress**: *[pubToAddress]()* =  pubToAddress
 
-*Defined in [index.ts:271](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L271)*
+*Defined in [account.ts:151](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L151)*
 
 ___
 <a id="setlength"></a>
@@ -174,7 +174,7 @@ ___
 
 **● setLength**: *[setLengthLeft]()* =  setLengthLeft
 
-*Defined in [index.ts:79](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L79)*
+*Defined in [bytes.ts:37](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L37)*
 
 ___
 <a id="stripzeros"></a>
@@ -183,7 +183,7 @@ ___
 
 **● stripZeros**: *[unpad]()* =  unpad
 
-*Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L106)*
+*Defined in [bytes.ts:64](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L64)*
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 ▸ **addHexPrefix**(str: *`string`*): `string`
 
-*Defined in [index.ts:488](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L488)*
+*Defined in [bytes.ts:135](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L135)*
 
 Adds "0x" to a given `String` if it does not already start with "0x".
 
@@ -212,9 +212,9 @@ ___
 
 ### `<Const>` baToJSON
 
-▸ **baToJSON**(ba: *`any`*): `undefined` \| `string` \| `any`[]
+▸ **baToJSON**(ba: *`any`*): `any`
 
-*Defined in [index.ts:540](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L540)*
+*Defined in [bytes.ts:148](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L148)*
 
 Converts a `Buffer` or `Array` to JSON.
 
@@ -224,7 +224,7 @@ Converts a `Buffer` or `Array` to JSON.
 | ------ | ------ | ------ |
 | ba | `any` |  (Buffer\|Array) |
 
-**Returns:** `undefined` \| `string` \| `any`[]
+**Returns:** `any`
 (Array|String|null)
 
 ___
@@ -234,7 +234,7 @@ ___
 
 ▸ **bufferToHex**(buf: *`Buffer`*): `string`
 
-*Defined in [index.ts:151](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L151)*
+*Defined in [bytes.ts:111](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L111)*
 
 Converts a `Buffer` into a hex `String`.
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **bufferToInt**(buf: *`Buffer`*): `number`
 
-*Defined in [index.ts:143](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L143)*
+*Defined in [bytes.ts:103](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L103)*
 
 Converts a `Buffer` to a `Number`.
 
@@ -272,7 +272,7 @@ ___
 
 ▸ **defineProperties**(self: *`any`*, fields: *`any`*, data: *`any`*): `void`
 
-*Defined in [index.ts:562](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L562)*
+*Defined in [object.ts:17](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/object.ts#L17)*
 
 Defines properties on a `Object`. It make the assumption that underlying data is binary.
 
@@ -293,7 +293,7 @@ ___
 
 ▸ **ecrecover**(msgHash: *`Buffer`*, v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, chainId?: *`undefined` \| `number`*): `Buffer`
 
-*Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L329)*
+*Defined in [signature.ts:36](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L36)*
 
 ECDSA public key recovery from signature.
 
@@ -317,7 +317,7 @@ ___
 
 ▸ **ecsign**(msgHash: *`Buffer`*, privateKey: *`Buffer`*, chainId?: *`undefined` \| `number`*): [ECDSASignature](interfaces/ecdsasignature.md)
 
-*Defined in [index.ts:297](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L297)*
+*Defined in [signature.ts:15](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L15)*
 
 Returns the ECDSA signature of a message hash.
 
@@ -338,7 +338,7 @@ ___
 
 ▸ **fromRpcSig**(sig: *`string`*): [ECDSASignature](interfaces/ecdsasignature.md)
 
-*Defined in [index.ts:363](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L363)*
+*Defined in [signature.ts:70](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L70)*
 
 Convert signature format of the `eth_sign` RPC method to signature parameters NOTE: all because of a bug in geth: [https://github.com/ethereum/go-ethereum/issues/2053](https://github.com/ethereum/go-ethereum/issues/2053)
 
@@ -357,7 +357,7 @@ ___
 
 ▸ **fromSigned**(num: *`Buffer`*): `BN`
 
-*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L160)*
+*Defined in [bytes.ts:120](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L120)*
 
 Interprets a `Buffer` as a signed integer and returns a `BN`. Assumes 256-bit numbers.
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **generateAddress**(from: *`Buffer`*, nonce: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:438](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L438)*
+*Defined in [account.ts:63](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L63)*
 
 Generates an address of a newly created contract.
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **generateAddress2**(from: *`Buffer` \| `string`*, salt: *`Buffer` \| `string`*, initCode: *`Buffer` \| `string`*): `Buffer`
 
-*Defined in [index.ts:458](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L458)*
+*Defined in [account.ts:83](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L83)*
 
 Generates an address for a contract created using CREATE2.
 
@@ -415,9 +415,9 @@ ___
 
 ### `<Const>` hashPersonalMessage
 
-▸ **hashPersonalMessage**(message: *`any`*): `Buffer`
+▸ **hashPersonalMessage**(message: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:320](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L320)*
+*Defined in [signature.ts:136](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L136)*
 
 Returns the keccak-256 hash of `message`, prefixed with the header used by the `eth_sign` RPC call. The output of this function can be fed into `ecsign` to produce the same signature as the `eth_sign` call for a given `message`, or fed to `ecrecover` along with a signature to recover the public key used to produce the signature.
 
@@ -425,7 +425,7 @@ Returns the keccak-256 hash of `message`, prefixed with the header used by the `
 
 | Name | Type |
 | ------ | ------ |
-| message | `any` |
+| message | `Buffer` |
 
 **Returns:** `Buffer`
 
@@ -436,7 +436,7 @@ ___
 
 ▸ **importPublic**(publicKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:286](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L286)*
+*Defined in [account.ts:174](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L174)*
 
 Converts a public key to the Ethereum format.
 
@@ -455,7 +455,7 @@ ___
 
 ▸ **isPrecompiled**(address: *`Buffer` \| `string`*): `boolean`
 
-*Defined in [index.ts:480](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L480)*
+*Defined in [account.ts:105](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L105)*
 
 Returns true if the supplied address belongs to a precompiled account (Byzantium).
 
@@ -474,7 +474,7 @@ ___
 
 ▸ **isValidAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:395](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L395)*
+*Defined in [account.ts:20](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L20)*
 
 Checks if the address is a valid. Accepts checksummed addresses too.
 
@@ -493,7 +493,7 @@ ___
 
 ▸ **isValidChecksumAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:429](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L429)*
+*Defined in [account.ts:54](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L54)*
 
 Checks if the address is a valid checksummed address.
 
@@ -512,7 +512,7 @@ ___
 
 ▸ **isValidPrivate**(privateKey: *`Buffer`*): `boolean`
 
-*Defined in [index.ts:233](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L233)*
+*Defined in [account.ts:113](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L113)*
 
 Checks if the private key satisfies the rules of the curve secp256k1.
 
@@ -531,7 +531,7 @@ ___
 
 ▸ **isValidPublic**(publicKey: *`Buffer`*, sanitize?: *`boolean`*): `boolean`
 
-*Defined in [index.ts:243](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L243)*
+*Defined in [account.ts:123](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L123)*
 
 Checks if the public key satisfies the rules of the curve secp256k1 and the requirements of Ethereum.
 
@@ -551,7 +551,7 @@ ___
 
 ▸ **isValidSignature**(v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, homesteadOrLater?: *`boolean`*, chainId?: *`undefined` \| `number`*): `boolean`
 
-*Defined in [index.ts:500](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L500)*
+*Defined in [signature.ts:95](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L95)*
 
 Validate a ECDSA signature.
 
@@ -574,7 +574,7 @@ ___
 
 ▸ **isZeroAddress**(address: *`string`*): `boolean`
 
-*Defined in [index.ts:402](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L402)*
+*Defined in [account.ts:27](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L27)*
 
 Checks if a given address is a zero address.
 
@@ -593,7 +593,7 @@ ___
 
 ▸ **keccak**(a: *`any`*, bits?: *`number`*): `Buffer`
 
-*Defined in [index.ts:177](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L177)*
+*Defined in [hash.ts:13](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L13)*
 
 Creates Keccak hash of the input
 
@@ -601,7 +601,7 @@ Creates Keccak hash of the input
 
 | Name | Type | Default value | Description |
 | ------ | ------ | ------ | ------ |
-| a | `any` | - |  The input data (Buffer\|Array\|String\|Number) |
+| a | `any` | - |  The input data (Buffer\|Array\|String\|Number) If the string is a 0x-prefixed hex value it's interpreted as hexadecimal, otherwise as utf8. |
 | `Default value` bits | `number` | 256 |  The Keccak width |
 
 **Returns:** `Buffer`
@@ -613,7 +613,7 @@ ___
 
 ▸ **keccak256**(a: *`any`*): `Buffer`
 
-*Defined in [index.ts:190](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L190)*
+*Defined in [hash.ts:31](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L31)*
 
 Creates Keccak-256 hash of the input, alias for keccak(a, 256).
 
@@ -632,7 +632,7 @@ ___
 
 ▸ **privateToAddress**(privateKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:388](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L388)*
+*Defined in [account.ts:157](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L157)*
 
 Returns the ethereum address of a given private key.
 
@@ -651,7 +651,7 @@ ___
 
 ▸ **privateToPublic**(privateKey: *`Buffer`*): `Buffer`
 
-*Defined in [index.ts:277](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L277)*
+*Defined in [account.ts:165](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L165)*
 
 Returns the ethereum public key of a given private key.
 
@@ -670,7 +670,7 @@ ___
 
 ▸ **pubToAddress**(pubKey: *`Buffer`*, sanitize?: *`boolean`*): `Buffer`
 
-*Defined in [index.ts:262](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L262)*
+*Defined in [account.ts:142](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L142)*
 
 Returns the ethereum address of a given public key. Accepts "Ethereum public keys" and SEC1 encoded keys.
 
@@ -690,7 +690,7 @@ ___
 
 ▸ **ripemd160**(a: *`any`*, padded: *`boolean`*): `Buffer`
 
-*Defined in [index.ts:210](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L210)*
+*Defined in [hash.ts:51](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L51)*
 
 Creates RIPEMD160 hash of the input.
 
@@ -710,7 +710,7 @@ ___
 
 ▸ **rlphash**(a: *`rlp.Input`*): `Buffer`
 
-*Defined in [index.ts:226](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L226)*
+*Defined in [hash.ts:67](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L67)*
 
 Creates SHA-3 hash of the RLP encoded version of the input.
 
@@ -729,7 +729,7 @@ ___
 
 ▸ **setLengthLeft**(msg: *`any`*, length: *`number`*, right?: *`boolean`*): `any`
 
-*Defined in [index.ts:62](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L62)*
+*Defined in [bytes.ts:20](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L20)*
 
 Left Pads an `Array` or `Buffer` with leading zeros till it has `length` bytes. Or it truncates the beginning if it exceeds.
 
@@ -751,7 +751,7 @@ ___
 
 ▸ **setLengthRight**(msg: *`any`*, length: *`number`*): `any`
 
-*Defined in [index.ts:88](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L88)*
+*Defined in [bytes.ts:46](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L46)*
 
 Right Pads an `Array` or `Buffer` with leading zeros till it has `length` bytes. Or it truncates the beginning if it exceeds.
 
@@ -772,7 +772,7 @@ ___
 
 ▸ **sha256**(a: *`any`*): `Buffer`
 
-*Defined in [index.ts:198](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L198)*
+*Defined in [hash.ts:39](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/hash.ts#L39)*
 
 Creates SHA256 hash of the input.
 
@@ -791,7 +791,7 @@ ___
 
 ▸ **toBuffer**(v: *`any`*): `Buffer`
 
-*Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L112)*
+*Defined in [bytes.ts:70](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L70)*
 
 Attempts to turn a value into a `Buffer`. As input it supports `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` method.
 
@@ -810,7 +810,7 @@ ___
 
 ▸ **toChecksumAddress**(address: *`string`*): `string`
 
-*Defined in [index.ts:410](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L410)*
+*Defined in [account.ts:35](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L35)*
 
 Returns a checksummed address.
 
@@ -829,7 +829,7 @@ ___
 
 ▸ **toRpcSig**(v: *`number`*, r: *`Buffer`*, s: *`Buffer`*, chainId?: *`undefined` \| `number`*): `string`
 
-*Defined in [index.ts:349](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L349)*
+*Defined in [signature.ts:56](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L56)*
 
 Convert signature parameters into the format of `eth_sign` RPC method.
 
@@ -852,7 +852,7 @@ ___
 
 ▸ **toUnsigned**(num: *`BN`*): `Buffer`
 
-*Defined in [index.ts:168](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L168)*
+*Defined in [bytes.ts:128](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L128)*
 
 Converts a `BN` to an unsigned integer and returns it as a `Buffer`. Assumes 256-bit numbers.
 
@@ -871,7 +871,7 @@ ___
 
 ▸ **unpad**(a: *`any`*): `any`
 
-*Defined in [index.ts:97](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L97)*
+*Defined in [bytes.ts:55](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L55)*
 
 Trims leading zeros from a `Buffer` or an `Array`.
 
@@ -891,7 +891,7 @@ ___
 
 ▸ **zeroAddress**(): `string`
 
-*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L48)*
+*Defined in [account.ts:11](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/account.ts#L11)*
 
 Returns a zero address.
 
@@ -904,7 +904,7 @@ ___
 
 ▸ **zeros**(bytes: *`number`*): `Buffer`
 
-*Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L41)*
+*Defined in [bytes.ts:8](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/bytes.ts#L8)*
 
 Returns a buffer filled with 0s.
 

--- a/docs/interfaces/ecdsasignature.md
+++ b/docs/interfaces/ecdsasignature.md
@@ -24,7 +24,7 @@
 
 **● r**: *`Buffer`*
 
-*Defined in [index.ts:13](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L13)*
+*Defined in [signature.ts:8](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L8)*
 
 ___
 <a id="s"></a>
@@ -33,7 +33,7 @@ ___
 
 **● s**: *`Buffer`*
 
-*Defined in [index.ts:14](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L14)*
+*Defined in [signature.ts:9](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L9)*
 
 ___
 <a id="v"></a>
@@ -42,7 +42,7 @@ ___
 
 **● v**: *`number`*
 
-*Defined in [index.ts:12](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/index.ts#L12)*
+*Defined in [signature.ts:7](https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L7)*
 
 ___
 

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -76,7 +76,7 @@ export const toBuffer = function(v: any): Buffer {
         v = Buffer.from(ethjsUtil.padToEven(ethjsUtil.stripHexPrefix(v)), 'hex')
       } else {
         throw new Error(
-          'Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings.',
+          `Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: ${v}`,
         )
       }
     } else if (typeof v === 'number') {

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -75,7 +75,9 @@ export const toBuffer = function(v: any): Buffer {
       if (ethjsUtil.isHexString(v)) {
         v = Buffer.from(ethjsUtil.padToEven(ethjsUtil.stripHexPrefix(v)), 'hex')
       } else {
-        v = Buffer.from(v)
+        throw new Error(
+          'Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings.',
+        )
       }
     } else if (typeof v === 'number') {
       v = ethjsUtil.intToBuffer(v)

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,15 +1,22 @@
 const createKeccakHash = require('keccak')
 const createHash = require('create-hash')
+const ethjsUtil = require('ethjs-util')
 import rlp = require('rlp')
 import { toBuffer, setLength } from './bytes'
 
 /**
  * Creates Keccak hash of the input
- * @param a The input data (Buffer|Array|String|Number)
+ * @param a The input data (Buffer|Array|String|Number) If the string is a 0x-prefixed hex value
+ * it's interpreted as hexadecimal, otherwise as utf8.
  * @param bits The Keccak width
  */
 export const keccak = function(a: any, bits: number = 256): Buffer {
-  a = toBuffer(a)
+  if (typeof a === 'string' && !ethjsUtil.isHexString(a)) {
+    a = Buffer.from(a, 'utf8')
+  } else {
+    a = toBuffer(a)
+  }
+
   if (!bits) bits = 256
 
   return createKeccakHash(`keccak${bits}`)

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -134,7 +134,10 @@ export const isValidSignature = function(
  * used to produce the signature.
  */
 export const hashPersonalMessage = function(message: any): Buffer {
-  const prefix = toBuffer(`\u0019Ethereum Signed Message:\n${message.length.toString()}`)
+  const prefix = Buffer.from(
+    `\u0019Ethereum Signed Message:\n${message.length.toString()}`,
+    'utf-8',
+  )
   return keccak(Buffer.concat([prefix, message]))
 }
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -133,7 +133,7 @@ export const isValidSignature = function(
  * call for a given `message`, or fed to `ecrecover` along with a signature to recover the public key
  * used to produce the signature.
  */
-export const hashPersonalMessage = function(message: any): Buffer {
+export const hashPersonalMessage = function(message: Buffer): Buffer {
   const prefix = Buffer.from(
     `\u0019Ethereum Signed Message:\n${message.length.toString()}`,
     'utf-8',

--- a/test/defineFields.js
+++ b/test/defineFields.js
@@ -55,22 +55,22 @@ describe('define', function () {
   it('it should accept rlp encoded intial data', function () {
     var someOb = {}
     var data = {
-      aword: 'test',
-      cannotBeZero: 'not zero',
-      value: 'a value',
-      r: 'rrr'
+      aword: '0x01',
+      cannotBeZero: '0x02',
+      value: '0x03',
+      r: '0x04'
     }
 
     var expected = {
-      aword: '0x74657374',
+      aword: '0x01',
       empty: '0x',
-      cannotBeZero: '0x6e6f74207a65726f',
-      value: '0x612076616c7565',
-      r: '0x727272'
+      cannotBeZero: '0x02',
+      value: '0x03',
+      r: '0x04'
     }
 
     var expectedArray = [
-      '0x74657374', '0x', '0x6e6f74207a65726f', '0x612076616c7565', '0x727272'
+      '0x01', '0x', '0x02', '0x03', '0x04'
     ]
 
     ethUtil.defineProperties(someOb, fields, data)
@@ -100,25 +100,25 @@ describe('define', function () {
   it('alias should work ', function () {
     var someOb = {}
     var data = {
-      aword: 'test',
-      cannotBeZero: 'not zero',
-      value: 'a value',
-      r: 'rrr'
+      aword: '0x01',
+      cannotBeZero: '0x02',
+      value: '0x03',
+      r: '0x04'
     }
 
     ethUtil.defineProperties(someOb, fields, data)
-    assert.equal(someOb.blah.toString(), 'test')
-    someOb.blah = 'lol'
-    assert.equal(someOb.blah.toString(), 'lol')
-    assert.equal(someOb.aword.toString(), 'lol')
+    assert.equal(someOb.blah.toString('hex'), '01')
+    someOb.blah = '0x09'
+    assert.equal(someOb.blah.toString('hex'), '09')
+    assert.equal(someOb.aword.toString('hex'), '09')
   })
 
   it('alias should work #2', function () {
     var someOb = {}
-    var data = { blah: '42' }
+    var data = { blah: '0x1' }
 
     ethUtil.defineProperties(someOb, fields, data)
-    assert.equal(someOb.blah, '42')
-    assert.equal(someOb.aword, '42')
+    assert.equal(someOb.blah.toString('hex'), '01')
+    assert.equal(someOb.aword.toString('hex'), '01')
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -507,9 +507,9 @@ describe('toBuffer', function () {
   })
 
   it('should fail with non 0x-prefixed hex strings', function() {
-    assert.throws(() => ethUtils.toBuffer('11'))
+    assert.throws(() => ethUtils.toBuffer('11'), '11')
     assert.throws(() => ethUtils.toBuffer(''))
-    assert.throws(() => ethUtils.toBuffer('0xR'))
+    assert.throws(() => ethUtils.toBuffer('0xR'), '0xR')
   })
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -416,9 +416,11 @@ describe('privateToAddress', function () {
   })
 })
 
-describe('generateAddress', function () {
-  it('should produce an address given a public key', function () {
-    const add = ethUtils.generateAddress('990ccf8a0de58091c028d6ff76bb235ee67c1c39', 14).toString('hex')
+describe('generateAddress', function() {
+  it('should produce an address given a public key', function() {
+    const add = ethUtils
+      .generateAddress(Buffer.from('990ccf8a0de58091c028d6ff76bb235ee67c1c39', 'utf8'), 14)
+      .toString('hex')
     assert.equal(add.toString('hex'), '936a4295d8d74e310c0c95f0a63e53737b998d12')
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -484,10 +484,9 @@ describe('toBuffer', function () {
     // Array
     assert.deepEqual(ethUtils.toBuffer([]), Buffer.allocUnsafe(0))
     // String
-    assert.deepEqual(ethUtils.toBuffer('11'), Buffer.from([49, 49]))
     assert.deepEqual(ethUtils.toBuffer('0x11'), Buffer.from([17]))
-    assert.deepEqual(ethUtils.toBuffer('1234').toString('hex'), '31323334')
     assert.deepEqual(ethUtils.toBuffer('0x1234').toString('hex'), '1234')
+    assert.deepEqual(ethUtils.toBuffer('0x'), Buffer.from([]))
     // Number
     assert.deepEqual(ethUtils.toBuffer(1), Buffer.from([1]))
     // null
@@ -503,6 +502,12 @@ describe('toBuffer', function () {
     assert.throws(function () {
       ethUtils.toBuffer({ test: 1 })
     })
+  })
+
+  it('should fail with non 0x-prefixed hex strings', function() {
+    assert.throws(() => ethUtils.toBuffer('11'))
+    assert.throws(() => ethUtils.toBuffer(''))
+    assert.throws(() => ethUtils.toBuffer('0xR'))
   })
 })
 


### PR DESCRIPTION
I made this in response to the conversation we had in [this other PR](https://github.com/ethereumjs/ethereumjs-tx/pull/144).

As we agreed three, `toBuffer` had a surprising and error-prone behavior when a string other than 0x-prefixed hex one was given. This PR removes that behavior, throwing a clear error instead.

There were a few tests using this older behavior (i.e. passing utf-8 string), but that was not necessary and they were harder to read, so I replaced with equivalent 0x-prefixed hex strings.

`keccak` was also using and exposing this behavior, which makes sense as people sometimes hash strings. I implemented it inside `keccack` and documented it.

Finally, `hashPersonalMessage` was using it internally, but not exposing it, so I just updated it to an equivalent lower-level implementation.

Technically, this PR introduces a breaking change in `toBuffer`, but I think virtually all of the uses of `toBuffer` with non-hex strings were errors, as its behavior was unexpected and undocumented.
