### PR TITLE
Update travis config to support node 8, 10, 11, and 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
-env:
-  - CXX=g++-4.8
+  - "11"
+  - "12"
 addons:
   firefox: "latest"
   apt:


### PR DESCRIPTION
This PR udates the Travis config to run the tests against all the actively maintained node versions.