### PR TITLE
Fix Travis's xvfb service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ node_js:
   - "11"
   - "12"
 addons:
-  firefox: "latest"
+  chrome: stable
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-before_install:
-  - sh -e /etc/init.d/xvfb start
 env:
   global:
     - DISPLAY=:99.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,9 +37,6 @@ module.exports = function (config) {
       enabled: true,
       usePhantomJS: false,
       postDetection: function (availableBrowser) {
-        if (process.env.TRAVIS) {
-          return ['Firefox']
-        }
         if (availableBrowser.includes('Chrome')) {
           return ['ChromeHeadless']
         }


### PR DESCRIPTION
Currently CI is failing due to a common Travis xvfb issue along some distribution update.

This PR fixes the CI build analogue to applied solutions like https://github.com/ethereumjs/merkle-patricia-tree/pull/97.

@alcuadrado Sorry, read your [comment](https://github.com/ethereumjs/ethereumjs-util/issues/220#issuecomment-548973699) on using `chrome-headless`. I have a huge work back log though atm so I decided to stick to the works-for-sure-since-tested solution. We can nevertheless definitely keep this in discussion respectively do a test/first PR on this on occasion.

Also did some short Google search on this and found [these Travis docs](https://docs.travis-ci.com/user/gui-and-headless-browsers/), `chrome-headless` solution seemed to me structurally pretty similar to the current `Firefox` usage at first sight, might be wrong on this though.

Anyhow, would be glad if we can merge on first round this version to get things going again quickly.

@s1na just had a look that the latest release here is also quite some time ago and we didn't release the new file structure yet (see current [closed PR list](https://github.com/ethereumjs/ethereumjs-util/pulls?q=is%3Apr+is%3Aclosed)), together with some other new features (`EIP-1191` checksum algorithm support). I would do a subsequent PR after this one is merged - eventually together with some dependency updates - preparing a minor `v6.2.0` release, would you go along with this (@alcuadrado as well)?