### PR TITLE
Add basic API tests for re-exports

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -14,7 +14,7 @@ import { toBuffer, baToJSON, stripZeros } from './bytes'
  * @param data data to be validated against the definitions
  * @deprecated
  */
-export const defineProperties = function(self: any, fields: any, data: any) {
+export const defineProperties = function(self: any, fields: any, data?: any) {
   self.raw = []
   self._fields = []
 

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -1,5 +1,6 @@
-import assert = require('assert')
-const {
+import * as assert from 'assert'
+import * as BN from 'bn.js'
+import {
   isValidPrivate,
   isValidPublic,
   importPublic,
@@ -13,8 +14,7 @@ const {
   isValidChecksumAddress,
   isValidAddress,
   toChecksumAddress,
-} = require('../src')
-import BN = require('bn.js')
+} from '../src'
 const eip1014Testdata = require('./testdata/eip1014Examples.json')
 
 describe('isValidPrivate', function() {

--- a/test/bytes.spec.ts
+++ b/test/bytes.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
-const {
+import * as BN from 'bn.js'
+import {
   zeros,
   zeroAddress,
   isZeroAddress,
@@ -8,16 +9,13 @@ const {
   setLengthLeft,
   setLengthRight,
   bufferToHex,
-  intToHex,
-  intToBuffer,
   bufferToInt,
   fromSigned,
   toUnsigned,
   addHexPrefix,
   toBuffer,
   baToJSON,
-} = require('../src')
-import BN = require('bn.js')
+} from '../src'
 
 describe('zeros function', function() {
   it('should produce lots of 0s', function() {
@@ -109,22 +107,6 @@ describe('bufferToHex', function() {
   })
 })
 
-describe('intToHex', function() {
-  it('should convert a int to hex', function() {
-    const i = 6003400
-    const hex = intToHex(i)
-    assert.equal(hex, '0x5b9ac8')
-  })
-})
-
-describe('intToBuffer', function() {
-  it('should convert a int to a buffer', function() {
-    const i = 6003400
-    const buf = intToBuffer(i)
-    assert.equal(buf.toString('hex'), '5b9ac8')
-  })
-})
-
 describe('bufferToInt', function() {
   it('should convert a int to hex', function() {
     const buf = Buffer.from('5b9ac8', 'hex')
@@ -178,7 +160,7 @@ describe('hex prefix', function() {
     assert.equal(addHexPrefix(string), '0x' + string)
   })
   it('should return on non-string input', function() {
-    assert.equal(addHexPrefix(1), 1)
+    assert.equal(addHexPrefix(1 as any), 1)
   })
 })
 

--- a/test/constants.spec.ts
+++ b/test/constants.spec.ts
@@ -1,5 +1,5 @@
-import assert = require('assert')
-const {
+import * as assert from 'assert'
+import {
   MAX_INTEGER,
   TWO_POW256,
   KECCAK256_NULL_S,
@@ -8,7 +8,7 @@ const {
   KECCAK256_RLP_ARRAY,
   KECCAK256_RLP_S,
   KECCAK256_RLP,
-} = require('../src')
+} from '../src'
 
 describe('constants', function() {
   it('should match constants', function() {

--- a/test/externals.spec.ts
+++ b/test/externals.spec.ts
@@ -1,29 +1,167 @@
-import assert = require('assert')
+import * as assert from 'assert'
 
 import * as BN_export from 'bn.js'
 import * as rlp_export from 'rlp'
 import * as secp256k1_export from 'secp256k1'
 
-const ethjsUtil = require('ethjs-util')
-
 import * as src from '../src'
 
-describe('externals', function() {
-  it('should export `BN`', function() {
+describe('External BN export', () => {
+  it('should export `BN`', () => {
     assert.equal(src.BN, BN_export)
   })
 
-  it('should export `rlp`', function() {
+  it('should use a BN function correctly', () => {
+    const a = new src.BN('dead', 16)
+    const b = new src.BN('101010', 2)
+    const result = a.add(b)
+    assert.equal(result.toString(10), 57047)
+  })
+
+  it('should throw on exceptions', () => {
+    // should not allow 0 input
+    assert.throws(() => {
+      new src.BN(1).egcd(new src.BN('0'))
+    }, /^Error: Assertion failed$/)
+  })
+
+  // should not accept an unsafe integer
+  const num = Math.pow(2, 53)
+  assert.throws(() => {
+    return new src.BN(num, 10)
+  }, /^Error: Assertion failed$/)
+
+  // should throw error with num eq 0x4000000
+  assert.throws(function() {
+    new src.BN(0).iaddn(0x4000000)
+  }, /^Error: Assertion failed$/)
+})
+
+describe('External rlp export', () => {
+  it('should export `rlp`', () => {
     assert.equal(src.rlp, rlp_export)
   })
 
-  it('should export `scep256k1`', function() {
+  it('should use a rlp function correctly', () => {
+    const nestedList = [[], [[]], [[], [[]]]]
+    var encoded = src.rlp.encode(nestedList)
+    var decoded = src.rlp.decode(encoded)
+    assert.deepEqual(nestedList, decoded)
+  })
+
+  it('should throw on exceptions', () => {
+    // bad values: wrong encoded a zero
+    const val = Buffer.from(
+      'f9005f030182520894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3',
+      'hex',
+    )
+    let result
+    try {
+      result = src.rlp.decode(val)
+    } catch (e) {}
+    assert.equal(result, undefined)
+
+    // bad values: invalid length
+    const a = Buffer.from(
+      'f86081000182520894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3',
+      'hex',
+    )
+
+    let res
+    try {
+      result = src.rlp.decode(a)
+    } catch (e) {}
+    assert.equal(res, undefined)
+  })
+})
+
+describe('External secp256k1 export', () => {
+  it('should export `secp256k1`', () => {
     assert.equal(src.secp256k1, secp256k1_export)
   })
 
-  it('should have `ethjs-util` methods', function() {
-    for (const property in ethjsUtil) {
-      assert.ok(src.hasOwnProperty(property))
-    }
+  it('should use a secp256k1 function correctly', () => {
+    // generate message to sign
+    const msg = Buffer.from(
+      '983232e10f8d440b3bde2c0787084b1228a0a0bd6d18bf78165696bc76f3530e',
+      'hex',
+    )
+    // generate privKey
+    const privKey = Buffer.from(
+      '59812df42e7bbb8f60a0ae92c660dcb6700927f944c709eaa0b9447d9ebffaf7',
+      'hex',
+    )
+    // get the public key in a compressed format
+    const pubKey = src.secp256k1.publicKeyCreate(privKey)
+    // sign the message
+    const sigObj = src.secp256k1.sign(msg, privKey)
+    // verify the signature
+    assert.ok(src.secp256k1.verify(msg, sigObj.signature, pubKey))
+  })
+
+  it('should throw on exceptions', () => {
+    // publicKeyVerify should be a Buffer
+    assert.throws(() => {
+      src.secp256k1.publicKeyVerify(null as any)
+    })
+
+    // publicKeyCombine public keys should have length greater that zero
+    assert.throws(() => {
+      src.secp256k1.publicKeyCombine([])
+    })
+
+    // privateKeyImport invalid format
+    assert.throws(() => {
+      const buffer = Buffer.from([0x00])
+      src.secp256k1.privateKeyImport(buffer)
+    })
+  })
+})
+
+describe('External ethjsUtil export', () => {
+  it('should have all ethjsUtil methods', () => {
+    const expected = [
+      'arrayContainsArray',
+      'toBuffer',
+      'intToBuffer',
+      'getBinarySize',
+      'stripHexPrefix',
+      'isHexPrefixed',
+      'padToEven',
+      'intToHex',
+      'fromAscii',
+      'fromUtf8',
+      'toAscii',
+      'getKeys',
+      'isHexString',
+      'toUtf8',
+    ]
+
+    expected.forEach(prop => {
+      assert.ok(src.hasOwnProperty(prop))
+    })
+  })
+
+  it('should use ethjsUtil functions correctly', () => {
+    // should convert intToHex
+    assert.equal((src as any).intToHex(new src.BN(0)), '0x0')
+
+    // should convert intToHex
+    const i = 6003400
+    const hex = (src as any).intToHex(i)
+    assert.equal(hex, '0x5b9ac8')
+
+    // should convert a int to a buffer
+    const j = 6003400
+    const buf = (src as any).intToBuffer(j)
+    assert.equal(buf.toString('hex'), '5b9ac8')
+  })
+
+  it('should handle exceptions and invalid inputs', () => {
+    // should throw when invalid abi
+    assert.throws(() => (src as any).getKeys([], 3289), Error)
+
+    // should detect invalid length hex string
+    assert.equal((src as any).isHexString('0x0', 2), false)
   })
 })

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -1,5 +1,5 @@
-import assert = require('assert')
-const { keccak, keccak256, sha256, ripemd160, rlphash } = require('../src')
+import * as assert from 'assert'
+import { keccak, keccak256, sha256, ripemd160, rlphash } from '../src'
 
 describe('keccak', function() {
   it('should produce a hash', function() {

--- a/test/object.spec.ts
+++ b/test/object.spec.ts
@@ -1,5 +1,5 @@
-var assert = require('assert')
-const { zeros, defineProperties } = require('../src')
+import * as assert from 'assert'
+import { zeros, defineProperties } from '../src'
 
 describe('define', function() {
   const fields = [

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -1,5 +1,6 @@
-import assert = require('assert')
-const {
+import * as assert from 'assert'
+import * as BN from 'bn.js'
+import {
   ecsign,
   ecrecover,
   privateToPublic,
@@ -7,8 +8,7 @@ const {
   isValidSignature,
   fromRpcSig,
   toRpcSig,
-} = require('../src')
-import BN = require('bn.js')
+} from '../src'
 
 const echash = Buffer.from(
   '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28',


### PR DESCRIPTION
This PR adds some basic tests for the re-exports in the new test file `externals.spec.ts`:

```
  External BN export
    ✓ should export `BN`
    ✓ should use a BN function correctly
    ✓ should throw on exceptions

  External rlp export
    ✓ should export `rlp`
    ✓ should use a rlp function correctly
    ✓ should throw on exceptions

  External secp256k1 export
    ✓ should export `secp256k1`
    ✓ should use a secp256k1 function correctly
    ✓ should throw on exceptions

  External ethjsUtil export
    ✓ should have all ethjsUtil methods
    ✓ should use ethjsUtil functions correctly
    ✓ should handle exceptions and invalid inputs
```

Closes #234.