### PR TITLE
fix(package): update secp256k1 to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ethjs-util": "0.1.6",
     "keccak": "^3.0.0",
     "rlp": "^2.2.3",
-    "secp256k1": "^3.0.1"
+    "secp256k1": "^3.8.0"
   },
   "devDependencies": {
     "@ethereumjs/config-prettier": "^1.1.0",


### PR DESCRIPTION
secp256k1@3.8.0 uses version of `elliptic` with fixed circular dependency. This circular dependency breaks Rollup builds.

Reference: https://github.com/indutny/elliptic/pull/180