### PR TITLE
Update rlp dep and readme badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # SYNOPSIS
 
-[![NPM Package](https://img.shields.io/npm/v/ethereumjs-util.svg?style=flat-square)](https://www.npmjs.org/package/ethereumjs-util)
+[![NPM Package](https://img.shields.io/npm/v/ethereumjs-util.svg)](https://www.npmjs.org/package/ethereumjs-util)
 [![Actions Status](https://github.com/ethereumjs/ethereumjs-util/workflows/Build/badge.svg)](https://github.com/ethereumjs/ethereumjs-util/actions)
-[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-util.svg?style=flat-square)](https://coveralls.io/r/ethereumjs/ethereumjs-util)
-[![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs-lib.svg?style=flat-square)](https://gitter.im/ethereum/ethereumjs-lib) or #ethereumjs on freenode
+[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-util.svg)](https://coveralls.io/r/ethereumjs/ethereumjs-util)
+[![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs-lib.svg)](https://gitter.im/ethereum/ethereumjs-lib)
 
 A collection of utility functions for Ethereum. It can be used in Node.js and in the browser with [browserify](http://browserify.org/).
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "create-hash": "^1.1.2",
     "ethjs-util": "0.1.6",
     "keccak": "^3.0.0",
-    "rlp": "^2.2.3",
+    "rlp": "^2.2.4",
     "secp256k1": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR:
 * Removes the freenode badge
* Updates the badge style to default to match the gh actions badge
* Bumps rlp to `2.2.4` (shouldn't affect anything because already covered under previous range `^2.2.3`)