### PR TITLE
Enforce hex prefixing for address strings

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -2,8 +2,9 @@ const ethjsUtil = require('ethjs-util')
 import * as assert from 'assert'
 import * as secp256k1 from 'secp256k1'
 import * as BN from 'bn.js'
-import { toBuffer, addHexPrefix, zeros, bufferToHex, unpad } from './bytes'
+import { toBuffer, zeros, bufferToHex, unpad } from './bytes'
 import { keccak, keccak256, rlphash } from './hash'
+import { assertIsHexString } from './helpers'
 
 /**
  * Returns a zero address.
@@ -17,16 +18,18 @@ export const zeroAddress = function(): string {
 /**
  * Checks if the address is a valid. Accepts checksummed addresses too.
  */
-export const isValidAddress = function(address: string): boolean {
-  return /^0x[0-9a-fA-F]{40}$/.test(address)
+export const isValidAddress = function(hexAddress: string): boolean {
+  assertIsHexString(hexAddress)
+  return /^0x[0-9a-fA-F]{40}$/.test(hexAddress)
 }
 
 /**
  * Checks if a given address is a zero address.
  */
-export const isZeroAddress = function(address: string): boolean {
+export const isZeroAddress = function(hexAddress: string): boolean {
+  assertIsHexString(hexAddress)
   const zeroAddr = zeroAddress()
-  return zeroAddr === addHexPrefix(address)
+  return zeroAddr === hexAddress
 }
 
 /**
@@ -39,8 +42,9 @@ export const isZeroAddress = function(address: string): boolean {
  * WARNING: Checksums with and without the chainId will differ. As of 2019-06-26, the most commonly
  * used variation in Ethereum was without the chainId. This may change in the future.
  */
-export const toChecksumAddress = function(address: string, eip1191ChainId?: number): string {
-  address = ethjsUtil.stripHexPrefix(address).toLowerCase()
+export const toChecksumAddress = function(hexAddress: string, eip1191ChainId?: number): string {
+  assertIsHexString(hexAddress)
+  const address = ethjsUtil.stripHexPrefix(hexAddress).toLowerCase()
 
   const prefix = eip1191ChainId !== undefined ? eip1191ChainId.toString() + '0x' : ''
 
@@ -63,8 +67,11 @@ export const toChecksumAddress = function(address: string, eip1191ChainId?: numb
  *
  * See toChecksumAddress' documentation for details about the eip1191ChainId parameter.
  */
-export const isValidChecksumAddress = function(address: string, eip1191ChainId?: number): boolean {
-  return isValidAddress(address) && toChecksumAddress(address, eip1191ChainId) === address
+export const isValidChecksumAddress = function(
+  hexAddress: string,
+  eip1191ChainId?: number,
+): boolean {
+  return isValidAddress(hexAddress) && toChecksumAddress(hexAddress, eip1191ChainId) === hexAddress
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,12 @@
+const ethjsUtil = require('ethjs-util')
+
+/**
+ * Throws if a string is not hex prefixed
+ * @param {string} input string to check hex prefix of
+ */
+export const assertIsHexString = function(input: string): void {
+  const msg = `This method only supports 0x-prefixed hex strings but input was: ${input}`
+  if (!ethjsUtil.isHexString(input)) {
+    throw new Error(msg)
+  }
+}

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -473,6 +473,14 @@ describe('.toChecksumAddress()', function() {
       }
     })
   })
+
+  describe('input format', function() {
+    it('Should throw when the address is not hex-prefixed', function() {
+      assert.throws(function() {
+        toChecksumAddress('52908400098527886E0F7030069857D2E4169EE7'.toLowerCase())
+      })
+    })
+  })
 })
 
 describe('.isValidChecksumAddress()', function() {
@@ -513,6 +521,14 @@ describe('.isValidChecksumAddress()', function() {
       }
     })
   })
+
+  describe('input format', function() {
+    it('Should throw when the address is not hex-prefixed', function() {
+      assert.throws(function() {
+        isValidChecksumAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
+      })
+    })
+  })
 })
 
 describe('.isValidAddress()', function() {
@@ -521,10 +537,27 @@ describe('.isValidAddress()', function() {
     assert.equal(isValidAddress('0x52908400098527886E0F7030069857D2E4169EE7'), true)
   })
   it('should return false', function() {
-    assert.equal(isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a'), false)
     assert.equal(isValidAddress('0x2f015c60e0be116b1f0cd534704db9c92118fb6'), false)
     assert.equal(isValidAddress('0x2f015c60e0be116b1f0cd534704db9c92118fb6aa'), false)
-    assert.equal(isValidAddress('0X52908400098527886E0F7030069857D2E4169EE7'), false)
-    assert.equal(isValidAddress('x2f015c60e0be116b1f0cd534704db9c92118fb6a'), false)
+  })
+  it('should throw when input is not hex prefixed', function() {
+    assert.throws(function() {
+      isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
+    })
+    assert.throws(function() {
+      isValidAddress('x2f015c60e0be116b1f0cd534704db9c92118fb6a')
+    })
+    assert.throws(function() {
+      isValidAddress('0X52908400098527886E0F7030069857D2E4169EE7')
+    })
+  })
+  it('error message should have correct format', function() {
+    const input = '2f015c60e0be116b1f0cd534704db9c92118fb6a'
+    try {
+      isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
+    } catch (err) {
+      assert(err.message.includes('only supports 0x-prefixed hex strings'))
+      assert(err.message.includes(input))
+    }
   })
 })

--- a/test/bytes.spec.ts
+++ b/test/bytes.spec.ts
@@ -40,6 +40,12 @@ describe('is zero address', function() {
     const nonZeroAddress = '0x2f015c60e0be116b1f0cd534704db9c92118fb6a'
     assert.equal(isZeroAddress(nonZeroAddress), false)
   })
+
+  it('should throw when address is not hex-prefixed', function() {
+    assert.throws(function() {
+      isZeroAddress('0000000000000000000000000000000000000000')
+    })
+  })
 })
 
 describe('unpad', function() {


### PR DESCRIPTION
Part of #172 [Breaking API Changes][2]

The proposal to make hex param checking more strict in #172 comes out of review discussions in #170. [There][1] @holger suggested:

> Then we should at least pass input params to a dedicated check method and throw if no hex-prefix provided, and always return prefixed hex strings.

PR adds logic to enforce hex-prefixing for all address string inputs. Affected methods are:

+ isValidAddress
+ isZeroAddress
+ toChecksumAddress
+ isValidChecksumAddress  (via isValidAddress)

`isPrecompile` is excluded because it's targeted for removal in #242. 

[1]: https://github.com/ethereumjs/ethereumjs-util/pull/170#issuecomment-452318028
[2]: https://github.com/ethereumjs/ethereumjs-util/issues/172#issuecomment-491756771