### PR TITLE
Remove isPrecompiled method

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -2,7 +2,7 @@ const ethjsUtil = require('ethjs-util')
 import * as assert from 'assert'
 import * as secp256k1 from 'secp256k1'
 import * as BN from 'bn.js'
-import { toBuffer, addHexPrefix, zeros, bufferToHex, unpad } from './bytes'
+import { toBuffer, addHexPrefix, zeros, bufferToHex } from './bytes'
 import { keccak, keccak256, rlphash } from './hash'
 
 /**
@@ -109,14 +109,6 @@ export const generateAddress2 = function(
   )
 
   return address.slice(-20)
-}
-
-/**
- * Returns true if the supplied address belongs to a precompiled account (Byzantium).
- */
-export const isPrecompiled = function(address: Buffer | string): boolean {
-  const a = unpad(address)
-  return a.length === 1 && a[0] >= 1 && a[0] <= 8
 }
 
 /**

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -10,7 +10,6 @@ import {
   generateAddress,
   generateAddress2,
   toBuffer,
-  isPrecompiled,
   isValidChecksumAddress,
   isValidAddress,
   toChecksumAddress,
@@ -373,32 +372,6 @@ describe('generateAddress2: EIP-1014 testdata examples', function() {
       assert.equal('0x' + result.toString('hex'), e['result'])
     })
   }
-})
-
-describe('isPrecompiled', function() {
-  it('should return true', function() {
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000001'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000002'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000003'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000004'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000005'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000006'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000007'), true)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000008'), true)
-    assert.equal(
-      isPrecompiled(Buffer.from('0000000000000000000000000000000000000001', 'hex')),
-      true,
-    )
-  })
-  it('should return false', function() {
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000000'), false)
-    assert.equal(isPrecompiled('0000000000000000000000000000000000000009'), false)
-    assert.equal(isPrecompiled('1000000000000000000000000000000000000000'), false)
-    assert.equal(
-      isPrecompiled(Buffer.from('0000000000000000000000000000000000000000', 'hex')),
-      false,
-    )
-  })
 })
 
 const eip55ChecksumAddresses = [


### PR DESCRIPTION
Part of #172 [Breaking API Changes][1]
 
Per [#172 comment][1]:
 
> This is a very error-prone and implicitly-HF-dependent method anyhow, which I have once removed from the VM and which currently has no other usages with EthereumJS. We should consider to remove.

PR removes:
+ method
+ tests
+ documentation

[1]: https://github.com/ethereumjs/ethereumjs-util/issues/172#issuecomment-492118336
