### PR TITLE
Make hash methods type strict

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert'
 import * as secp256k1 from 'secp256k1'
 import * as BN from 'bn.js'
 import { zeros, bufferToHex, toBuffer } from './bytes'
-import { keccak, keccak256, rlphash } from './hash'
+import { keccak, keccak256, keccakFromString, rlphash } from './hash'
 import { assertIsHexString, assertIsBuffer } from './helpers'
 
 /**
@@ -48,7 +48,7 @@ export const toChecksumAddress = function(hexAddress: string, eip1191ChainId?: n
 
   const prefix = eip1191ChainId !== undefined ? eip1191ChainId.toString() + '0x' : ''
 
-  const hash = keccak(prefix + address).toString('hex')
+  const hash = keccakFromString(prefix + address).toString('hex')
   let ret = '0x'
 
   for (let i = 0; i < address.length; i++) {

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -54,10 +54,37 @@ export const keccakFromArray = function(a: number[], bits: number = 256) {
 }
 
 /**
- * Creates SHA256 hash of the input.
- * @param a The input data (Buffer|Array|String|Number)
+ * Creates SHA256 hash of a Buffer input.
+ * @param a The input data (Buffer)
  */
-export const sha256 = function(a: any): Buffer {
+export const sha256 = function(a: Buffer): Buffer {
+  assertIsBuffer(a)
+  return _sha256(a)
+}
+
+/**
+ * Creates SHA256 hash of a string input.
+ * @param a The input data (string)
+ */
+export const sha256FromString = function(a: string): Buffer {
+  assertIsString(a)
+  return _sha256(a)
+}
+
+/**
+ * Creates SHA256 hash of a number[] input.
+ * @param a The input data (number[])
+ */
+export const sha256FromArray = function(a: number[]): Buffer {
+  assertIsArray(a)
+  return _sha256(a)
+}
+
+/**
+ * Creates SHA256 hash of an input.
+ * @param  a The input data (Buffer|Array|String)
+ */
+const _sha256 = function(a: any): Buffer {
   a = toBuffer(a)
   return createHash('sha256')
     .update(a)

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -3,7 +3,7 @@ const createHash = require('create-hash')
 const ethjsUtil = require('ethjs-util')
 import * as rlp from 'rlp'
 import { toBuffer, setLengthLeft } from './bytes'
-import { assertIsString, assertIsBuffer, assertIsArray } from './helpers'
+import { assertIsString, assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
 
 /**
  * Creates Keccak hash of a Buffer input
@@ -26,21 +26,24 @@ export const keccak256 = function(a: Buffer): Buffer {
 }
 
 /**
- * Creates Keccak hash of a String input
- * @param a The input data (String) If string is 0x-prefixed hex value it's
- *          interpreted as hexadecimal, otherwise as utf8.
+ * Creates Keccak hash of a utf-8 string input
+ * @param a The input data (String)
  * @param bits (number = 256) The Keccak width
  */
 export const keccakFromString = function(a: string, bits: number = 256) {
   assertIsString(a)
-  let buf
-  if (!ethjsUtil.isHexString(a)) {
-    buf = Buffer.from(a, 'utf8')
-  } else {
-    buf = toBuffer(a)
-  }
-
+  const buf = Buffer.from(a, 'utf8')
   return keccak(buf, bits)
+}
+
+/**
+ * Creates Keccak hash of an 0x-prefixed string input
+ * @param a The input data (String)
+ * @param bits (number = 256) The Keccak width
+ */
+export const keccakFromHexString = function(a: string, bits: number = 256) {
+  assertIsHexString(a)
+  return keccak(toBuffer(a), bits)
 }
 
 /**

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -92,11 +92,41 @@ const _sha256 = function(a: any): Buffer {
 }
 
 /**
+ * Creates RIPEMD160 hash of a Buffer input.
+ * @param a The input data (Buffer)
+ * @param padded Whether it should be padded to 256 bits or not
+ */
+export const ripemd160 = function(a: Buffer, padded: boolean): Buffer {
+  assertIsBuffer(a)
+  return _ripemd160(a, padded)
+}
+
+/**
+ * Creates RIPEMD160 hash of a string input.
+ * @param a The input data (String)
+ * @param padded Whether it should be padded to 256 bits or not
+ */
+export const ripemd160FromString = function(a: string, padded: boolean): Buffer {
+  assertIsString(a)
+  return _ripemd160(a, padded)
+}
+
+/**
+ * Creates RIPEMD160 hash of a number[] input.
+ * @param a The input data (number[])
+ * @param padded Whether it should be padded to 256 bits or not
+ */
+export const ripemd160FromArray = function(a: number[], padded: boolean): Buffer {
+  assertIsArray(a)
+  return _ripemd160(a, padded)
+}
+
+/**
  * Creates RIPEMD160 hash of the input.
  * @param a The input data (Buffer|Array|String|Number)
  * @param padded Whether it should be padded to 256 bits or not
  */
-export const ripemd160 = function(a: any, padded: boolean): Buffer {
+const _ripemd160 = function(a: any, padded: boolean): Buffer {
   a = toBuffer(a)
   const hash = createHash('rmd160')
     .update(a)

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -3,22 +3,15 @@ const createHash = require('create-hash')
 const ethjsUtil = require('ethjs-util')
 import * as rlp from 'rlp'
 import { toBuffer, setLengthLeft } from './bytes'
+import { assertIsString, assertIsBuffer, assertIsArray } from './helpers'
 
 /**
- * Creates Keccak hash of the input
- * @param a The input data (Buffer|Array|String|Number) If the string is a 0x-prefixed hex value
- * it's interpreted as hexadecimal, otherwise as utf8.
- * @param bits The Keccak width
+ * Creates Keccak hash of a Buffer input
+ * @param a The input data (Buffer)
+ * @param bits (number = 256) The Keccak width
  */
-export const keccak = function(a: any, bits: number = 256): Buffer {
-  if (typeof a === 'string' && !ethjsUtil.isHexString(a)) {
-    a = Buffer.from(a, 'utf8')
-  } else {
-    a = toBuffer(a)
-  }
-
-  if (!bits) bits = 256
-
+export const keccak = function(a: Buffer, bits: number = 256): Buffer {
+  assertIsBuffer(a)
   return createKeccakHash(`keccak${bits}`)
     .update(a)
     .digest()
@@ -26,10 +19,38 @@ export const keccak = function(a: any, bits: number = 256): Buffer {
 
 /**
  * Creates Keccak-256 hash of the input, alias for keccak(a, 256).
- * @param a The input data (Buffer|Array|String|Number)
+ * @param a The input data (Buffer)
  */
-export const keccak256 = function(a: any): Buffer {
+export const keccak256 = function(a: Buffer): Buffer {
   return keccak(a)
+}
+
+/**
+ * Creates Keccak hash of a String input
+ * @param a The input data (String) If string is 0x-prefixed hex value it's
+ *          interpreted as hexadecimal, otherwise as utf8.
+ * @param bits (number = 256) The Keccak width
+ */
+export const keccakFromString = function(a: string, bits: number = 256) {
+  assertIsString(a)
+  let buf
+  if (!ethjsUtil.isHexString(a)) {
+    buf = Buffer.from(a, 'utf8')
+  } else {
+    buf = toBuffer(a)
+  }
+
+  return keccak(buf, bits)
+}
+
+/**
+ * Creates Keccak hash of a number array input
+ * @param a The input data (number[])
+ * @param bits (number = 256) The Keccak width
+ */
+export const keccakFromArray = function(a: number[], bits: number = 256) {
+  assertIsArray(a)
+  return keccak(toBuffer(a), bits)
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -32,3 +32,14 @@ export const assertIsArray = function(input: number[]): void {
     throw new Error(msg)
   }
 }
+
+/**
+ * Throws if input is not a string
+ * @param {string} input value to check
+ */
+export const assertIsString = function(input: string): void {
+  const msg = `This method only supports strings but input was: ${input}`
+  if (typeof input !== 'string') {
+    throw new Error(msg)
+  }
+}

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -2,6 +2,7 @@ import * as secp256k1 from 'secp256k1'
 import * as BN from 'bn.js'
 import { toBuffer, setLengthLeft, bufferToHex } from './bytes'
 import { keccak } from './hash'
+import { assertIsBuffer } from './helpers'
 
 export interface ECDSASignature {
   v: number
@@ -134,6 +135,7 @@ export const isValidSignature = function(
  * used to produce the signature.
  */
 export const hashPersonalMessage = function(message: Buffer): Buffer {
+  assertIsBuffer(message)
   const prefix = Buffer.from(
     `\u0019Ethereum Signed Message:\n${message.length.toString()}`,
     'utf-8',

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -8,6 +8,8 @@ import {
   sha256FromString,
   sha256FromArray,
   ripemd160,
+  ripemd160FromString,
+  ripemd160FromArray,
   rlphash,
   toBuffer,
 } from '../src'
@@ -131,15 +133,68 @@ describe('ripemd160', function() {
   it('should produce a ripemd160', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '4bb0246cbfdfddbe605a374f1187204c896fabfd'
-    const hash = ripemd160(msg, false)
+    const hash = ripemd160(toBuffer(msg), false)
     assert.equal(hash.toString('hex'), r)
   })
 
   it('should produce a padded ripemd160', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '0000000000000000000000004bb0246cbfdfddbe605a374f1187204c896fabfd'
-    const hash = ripemd160(msg, true)
+    const hash = ripemd160(toBuffer(msg), true)
     assert.equal(hash.toString('hex'), r)
+  })
+
+  it('should error if input is not Buffer', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      ripemd160((<unknown>msg) as Buffer, false)
+    })
+  })
+})
+
+describe('ripemd160FromString', function() {
+  it('should produce a ripemd160', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    const r = '4bb0246cbfdfddbe605a374f1187204c896fabfd'
+    const hash = ripemd160FromString(msg, false)
+    assert.equal(hash.toString('hex'), r)
+  })
+
+  it('should produce a padded ripemd160', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    const r = '0000000000000000000000004bb0246cbfdfddbe605a374f1187204c896fabfd'
+    const hash = ripemd160FromString(msg, true)
+    assert.equal(hash.toString('hex'), r)
+  })
+
+  it('should error if input is not a string', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      ripemd160FromString((<unknown>toBuffer(msg)) as string, false)
+    })
+  })
+})
+
+describe('ripemd160FromArray', function() {
+  it('should produce a ripemd160', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    const r = 'ddbb5062318b209e3dbfc389fe61840363050071'
+    const hash = ripemd160FromArray(arr, false)
+    assert.equal(hash.toString('hex'), r)
+  })
+
+  it('should produce a padded ripemd160', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    const r = '000000000000000000000000ddbb5062318b209e3dbfc389fe61840363050071'
+    const hash = ripemd160FromArray(arr, true)
+    assert.equal(hash.toString('hex'), r)
+  })
+
+  it('should error if input is not an array', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    assert.throws(function() {
+      ripemd160FromArray((<unknown>toBuffer(arr)) as number[], false)
+    })
   })
 })
 

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -3,6 +3,7 @@ import {
   keccak,
   keccak256,
   keccakFromString,
+  keccakFromHexString,
   keccakFromArray,
   sha256,
   sha256FromString,
@@ -39,13 +40,7 @@ describe('keccak256', function() {
 })
 
 describe('keccakFromString', function() {
-  it('with hexprefix should produce a hash', function() {
-    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
-    const r = '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28'
-    const hash = keccakFromString(msg)
-    assert.equal(hash.toString('hex'), r)
-  })
-  it('without hexprefix should produce a hash', function() {
+  it('should produce a hash', function() {
     const msg = '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '22ae1937ff93ec72c4d46ff3e854661e3363440acd6f6e4adf8f1a8978382251'
     const hash = keccakFromString(msg)
@@ -55,6 +50,27 @@ describe('keccakFromString', function() {
     const buf = toBuffer('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')
     assert.throws(function() {
       keccakFromString((<unknown>buf) as string)
+    })
+  })
+})
+
+describe('keccakFromHexString', function() {
+  it('should produce a hash', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    const r = '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28'
+    const hash = keccakFromHexString(msg)
+    assert.equal(hash.toString('hex'), r)
+  })
+  it('should throw if input is not hex-prefixed', function() {
+    const msg = '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      keccakFromHexString(msg)
+    })
+  })
+  it('should throw if input is not a string', function() {
+    const buf = toBuffer('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')
+    assert.throws(function() {
+      keccakFromHexString((<unknown>buf) as string)
     })
   })
 })

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -5,6 +5,8 @@ import {
   keccakFromString,
   keccakFromArray,
   sha256,
+  sha256FromString,
+  sha256FromArray,
   ripemd160,
   rlphash,
   toBuffer,
@@ -84,8 +86,44 @@ describe('sha256', function() {
   it('should produce a sha256', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '58bbda5e10bc11a32d808e40f9da2161a64f00b5557762a161626afe19137445'
-    const hash = sha256(msg)
+    const hash = sha256(toBuffer(msg))
     assert.equal(hash.toString('hex'), r)
+  })
+  it('should error if input is not Buffer', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      sha256((<unknown>msg) as Buffer)
+    })
+  })
+})
+
+describe('sha256FromString', function() {
+  it('should produce a sha256', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    const r = '58bbda5e10bc11a32d808e40f9da2161a64f00b5557762a161626afe19137445'
+    const hash = sha256FromString(msg)
+    assert.equal(hash.toString('hex'), r)
+  })
+  it('should error if input is not Buffer', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      sha256FromString((<unknown>toBuffer(msg)) as string)
+    })
+  })
+})
+
+describe('sha256FromArray', function() {
+  it('should produce a sha256', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    const r = '5443c487d45d01c56150d91e7a071c69a97939b1c57874b73989a9ff7875e86b'
+    const hash = sha256FromArray(arr)
+    assert.equal(hash.toString('hex'), r)
+  })
+  it('should error if input is not Buffer', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    assert.throws(function() {
+      sha256FromArray((<unknown>toBuffer(arr)) as number[])
+    })
   })
 })
 

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -1,12 +1,27 @@
 import * as assert from 'assert'
-import { keccak, keccak256, sha256, ripemd160, rlphash } from '../src'
+import {
+  keccak,
+  keccak256,
+  keccakFromString,
+  keccakFromArray,
+  sha256,
+  ripemd160,
+  rlphash,
+  toBuffer,
+} from '../src'
 
 describe('keccak', function() {
   it('should produce a hash', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28'
-    const hash = keccak(msg)
+    const hash = keccak(toBuffer(msg))
     assert.equal(hash.toString('hex'), r)
+  })
+  it('should error if input is not Buffer', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    assert.throws(function() {
+      keccak((<unknown>msg) as Buffer)
+    })
   })
 })
 
@@ -14,17 +29,44 @@ describe('keccak256', function() {
   it('should produce a hash (keccak(a, 256) alias)', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28'
-    const hash = keccak256(msg)
+    const hash = keccak256(toBuffer(msg))
     assert.equal(hash.toString('hex'), r)
   })
 })
 
-describe('keccak without hexprefix', function() {
-  it('should produce a hash', function() {
+describe('keccakFromString', function() {
+  it('with hexprefix should produce a hash', function() {
+    const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    const r = '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28'
+    const hash = keccakFromString(msg)
+    assert.equal(hash.toString('hex'), r)
+  })
+  it('without hexprefix should produce a hash', function() {
     const msg = '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r = '22ae1937ff93ec72c4d46ff3e854661e3363440acd6f6e4adf8f1a8978382251'
-    const hash = keccak(msg)
+    const hash = keccakFromString(msg)
     assert.equal(hash.toString('hex'), r)
+  })
+  it('should throw if input is not a string', function() {
+    const buf = toBuffer('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')
+    assert.throws(function() {
+      keccakFromString((<unknown>buf) as string)
+    })
+  })
+})
+
+describe('keccakFromArray', function() {
+  it('should produce a hash', function() {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+    const r = 'fba8669bd39e3257e64752758f3a0d3218865a15757c6b0bc48b8ef95bc8bfd5'
+    const hash = keccakFromArray(arr)
+    assert.equal(hash.toString('hex'), r)
+  })
+  it('should throw if input is not an array', function() {
+    const buf = toBuffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 0])
+    assert.throws(function() {
+      keccakFromArray((<unknown>buf) as number[])
+    })
   })
 })
 
@@ -33,7 +75,7 @@ describe('keccak-512', function() {
     const msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
     const r =
       '36fdacd0339307068e9ed191773a6f11f6f9f99016bd50f87fd529ab7c87e1385f2b7ef1ac257cc78a12dcb3e5804254c6a7b404a6484966b831eadc721c3d24'
-    const hash = keccak(msg, 512)
+    const hash = keccak(toBuffer(msg), 512)
     assert.equal(hash.toString('hex'), r)
   })
 })

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -94,6 +94,13 @@ describe('hashPersonalMessage', function() {
       Buffer.from('8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede', 'hex'),
     )
   })
+  it('should throw if input is not a buffer', function() {
+    try {
+      hashPersonalMessage((<unknown>[0, 1, 2, 3, 4]) as Buffer)
+    } catch (err) {
+      assert(err.message.includes('This method only supports Buffer'))
+    }
+  })
 })
 
 describe('isValidSignature', function() {


### PR DESCRIPTION
Part of #172 [Breaking API changes][1]

+ Makes `keccak`, `sha256` and `ripemd160` buffer-only and adds `fromString` and `fromArray` variants for those inputs.

+ Adds `assertIsBuffer` check to input of `hashPersonalMessage` (excluding the possibility that someone could submit an array).

**Notes**:

There are more methods in `signature.ts` which *could* have their params validated but overall that file seems to have clearly specified input types.

In adding convenience methods, I omitted `number` because idk if that's really used. However, this has been a valid input to the hash methods. 

[1]: https://github.com/ethereumjs/ethereumjs-util/issues/172#issuecomment-492118336




