### PR TITLE
New release v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.2] - 2020-05-25
+
+This patch release re-establishes the state of `v7.0.0` release and upgrades
+the `BN.js` re-export version back to `v5` since quick patches for both
+the `v5` ([v5.1.2](https://github.com/indutny/bn.js/releases/tag/v5.1.2)) and
+the `v4` branch ([v4.11.9](https://github.com/indutny/bn.js/releases/tag/v4.11.9))
+have been released to fix interoperability issues between the `BN.js` versions.
+
+This now makes it possible to move to the latest `BN.js` `v5` version and profit
+from future upgrades and patches.
+
+An upgrade is highly recommended, the `v7.0.1` release will be marked as
+deprecated along this release.
+
+See: Issue [#250](https://github.com/ethereumjs/ethereumjs-util/issues/250)
+
+[7.0.2]: https://github.com/ethereumjs/ethereumjs-util/compare/v7.0.1...v7.0.2
+
 ## [7.0.1] - 2020-05-15
+
+[DEPRECATED in favour of v7.0.2]
 
 This patch release downgrades the re-exported `BN.js` version from `v5` to
 `v4` (so a continuation of what has being used within the `v6.x` versions).
@@ -21,6 +41,8 @@ See: Issue [#250](https://github.com/ethereumjs/ethereumjs-util/issues/250)
 [7.0.1]: https://github.com/ethereumjs/ethereumjs-util/compare/v7.0.0...v7.0.1
 
 ## [7.0.0] - 2020-04-30
+
+[DEPRECATED in favour of v7.0.1]
 
 This release comes with significant changes to the API, updated versions of
 the core crypto libraries and substantial developer improvements in the form

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following methods are available provided by [ethjs-util](https://github.com/
 
 Additionally `ethereumjs-util` re-exports a few commonly-used libraries. These include:
 
-- [BN.js](https://github.com/indutny/bn.js) (version `4.x`)
+- [BN.js](https://github.com/indutny/bn.js) (version `5.x`)
 - [rlp](https://github.com/ethereumjs/rlp) (version `2.x`)
 
 # EthereumJS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-util",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "a collection of utility functions for Ethereum",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-util",
   "dependencies": {
     "@types/bn.js": "^4.11.3",
-    "bn.js": "^4.11.8",
+    "bn.js": "^5.1.2",
     "create-hash": "^1.1.2",
     "ethjs-util": "0.1.6",
     "keccak": "^3.0.0",


### PR DESCRIPTION
I hate to do this a bit, but I think it's best for the community in the longer run (though maybe not for our short-term release reputation 🤨 😛) to do another turn here and go back up again to `BN.js` `v5` now with the interoperability patches out.

This will ensure that the libraries will slowly get up to the latest version and will further profit from patches and upgrades (which will likely get published on the latest `v5` branch).