### PR TITLE
Fix large string copies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: npm install
       - run: npm run test
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,8 +5,8 @@ import * as ethjsUtil from 'ethjs-util'
  * @param {string} input string to check hex prefix of
  */
 export const assertIsHexString = function(input: string): void {
-  const msg = `This method only supports 0x-prefixed hex strings but input was: ${input}`
   if (!ethjsUtil.isHexString(input)) {
+    const msg = `This method only supports 0x-prefixed hex strings but input was: ${input}`
     throw new Error(msg)
   }
 }
@@ -16,8 +16,8 @@ export const assertIsHexString = function(input: string): void {
  * @param {Buffer} input value to check
  */
 export const assertIsBuffer = function(input: Buffer): void {
-  const msg = `This method only supports Buffer but input was: ${input}`
   if (!Buffer.isBuffer(input)) {
+    const msg = `This method only supports Buffer but input was: ${input}`
     throw new Error(msg)
   }
 }
@@ -27,8 +27,8 @@ export const assertIsBuffer = function(input: Buffer): void {
  * @param {number[]} input value to check
  */
 export const assertIsArray = function(input: number[]): void {
-  const msg = `This method only supports number arrays but input was: ${input}`
   if (!Array.isArray(input)) {
+    const msg = `This method only supports number arrays but input was: ${input}`
     throw new Error(msg)
   }
 }
@@ -38,8 +38,8 @@ export const assertIsArray = function(input: number[]): void {
  * @param {string} input value to check
  */
 export const assertIsString = function(input: string): void {
-  const msg = `This method only supports strings but input was: ${input}`
   if (typeof input !== 'string') {
+    const msg = `This method only supports strings but input was: ${input}`
     throw new Error(msg)
   }
 }


### PR DESCRIPTION
When implementing Homestead in [this PR](https://github.com/ethereumjs/ethereumjs-vm/pull/815) I ran into an issue when trying to copy SHA3 large buffers which is caused by `assertIsBuffer`. This copies Buffers with sizes which node cannot handle even if there are no errors:

```
Error: Cannot create a string longer than 0x3fffffe7 characters
    at Buffer.toString (buffer.js:777:17)
    at Object.exports.assertIsBuffer (/Volumes/Ethereum/ethereumjs-vm/node_modules/ethereumjs-util/src/helpers.ts:19:15)
    at Object.exports.keccak (/Volumes/Ethereum/ethereumjs-vm/node_modules/ethereumjs-util/src/hash.ts:14:3)
    at Object.exports.keccak256 (/Volumes/Ethereum/ethereumjs-vm/node_modules/ethereumjs-util/src/hash.ts:39:10)
```

When you try to copy a Buffer into a string which is too large, it throws. Besides that, it does not make sense to create these messages if there are no errors (this is unnecessary copying).