### PR TITLE
Fix the types of the BN and RLP re-exports

### DIFF
--- a/src/externals.ts
+++ b/src/externals.ts
@@ -7,8 +7,8 @@
 // TODO: This can be replaced with a normal ESM import once
 // the new major version of the typescript config package
 // is released and adopted here.
-import BN = require('bn.js');
-import rlp = require('rlp');
+import BN = require('bn.js')
+import rlp = require('rlp')
 
 /**
  * [`BN`](https://github.com/indutny/bn.js)

--- a/src/externals.ts
+++ b/src/externals.ts
@@ -4,8 +4,11 @@
  * @packageDocumentation
  */
 
-import * as BN from 'bn.js'
-import * as rlp from 'rlp'
+// TODO: This can be replaced with a normal ESM import once
+// the new major version of the typescript config package
+// is released and adopted here.
+import BN = require('bn.js');
+import rlp = require('rlp');
 
 /**
  * [`BN`](https://github.com/indutny/bn.js)


### PR DESCRIPTION
This PR fixes #267.

Here's an explanation of what I think was wrong, how I fixed, and how it can be simplified in the future.

1. BN and RLP are distributed as CJS modules, and use the `module.exports = ` pattern. This is ok in CJS, but doesn't make sense in ESM. `module.exports` is not the same as `export default`.

2. TS has a special syntax to do that, `export = obj`.

3. BN and RLP typings use that syntax.

3. To import modules using that syntax, you have to use `import A = require('A')` in ts.

4. This module was using `import * as A from 'A'` instead, which means something like "import the module namespace" in ESM. Not that module namespace is not a class in ESM, so ts gets confused if you try to initialize it. 

5. This worked anyway, as we are just reexporting it, so no error was triggered.

6. When a TS project tries to use it, ts complains about this error that went unnoticed here.

7. This make this CSJ/ESM compatibility mess easier, TS introduced the `esModuleInterop` flag, which let you use `import A as 'A'` to import CSJ modules. This breaks the ESM semantics a bit, but it's a great trade off. 

8. As I wrote in a TODO, we are gonna enable that flag in a future version of the ts config package, so this change can be simplified in the future.