### PR TITLE
Add `toBuffer()` method to Address, make `toBuffer()` function convert TransformableToBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For more info see the documentation or examples of usage in `test/account.spec.t
 A new file with helpful TypeScript types has been added to the exports of this project.
 
 In this release it contains `BNLike`, `BufferLike`, and `TransformableToBuffer`.
+
 ### Address.toBuffer()
 
 The Address class has as a new method `address.toBuffer()` that will give you a copy of the underlying `address.buf`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ For more info see the documentation or examples of usage in `test/account.spec.t
 A new file with helpful TypeScript types has been added to the exports of this project.
 
 In this release it contains `BNLike`, `BufferLike`, and `TransformableToBuffer`.
+### Address.toBuffer()
+
+The Address class has as a new method `address.toBuffer()` that will give you a copy of the underlying `address.buf`.
+
+### `toBuffer()` now converts TransformableToBuffer
+
+The `toBuffer()` exported function now additionally converts any object with a `toBuffer()` method.
 
 ## [7.0.5] - 2020-09-09
 

--- a/src/address.ts
+++ b/src/address.ts
@@ -88,4 +88,11 @@ export class Address {
   toString(): string {
     return '0x' + this.buf.toString('hex')
   }
+
+  /**
+   * Returns Buffer representation of address.
+   */
+  toBuffer(): Buffer {
+    return Buffer.from(this.buf)
+  }
 }

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -1,5 +1,5 @@
-import * as ethjsUtil from 'ethjs-util'
 import * as BN from 'bn.js'
+import { intToBuffer, stripHexPrefix, padToEven, isHexString, isHexPrefixed } from 'ethjs-util'
 import { assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
 
 /**
@@ -86,7 +86,7 @@ export const unpadArray = function(a: number[]): number[] {
  */
 export const unpadHexString = function(a: string): string {
   assertIsHexString(a)
-  a = ethjsUtil.stripHexPrefix(a)
+  a = stripHexPrefix(a)
   return stripZeros(a) as string
 }
 
@@ -113,15 +113,15 @@ export const toBuffer = function(v: any): Buffer {
     if (Array.isArray(v) || v instanceof Uint8Array) {
       v = Buffer.from(v as Uint8Array)
     } else if (typeof v === 'string') {
-      if (ethjsUtil.isHexString(v)) {
-        v = Buffer.from(ethjsUtil.padToEven(ethjsUtil.stripHexPrefix(v)), 'hex')
+      if (isHexString(v)) {
+        v = Buffer.from(padToEven(stripHexPrefix(v)), 'hex')
       } else {
         throw new Error(
           `Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: ${v}`,
         )
       }
     } else if (typeof v === 'number') {
-      v = ethjsUtil.intToBuffer(v)
+      v = intToBuffer(v)
     } else if (v === null || v === undefined) {
       v = Buffer.allocUnsafe(0)
     } else if (BN.isBN(v)) {
@@ -180,7 +180,7 @@ export const addHexPrefix = function(str: string): string {
     return str
   }
 
-  return ethjsUtil.isHexPrefixed(str) ? str : '0x' + str
+  return isHexPrefixed(str) ? str : '0x' + str
 }
 
 /**

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -2,6 +2,16 @@ import * as BN from 'bn.js'
 import { intToBuffer, stripHexPrefix, padToEven, isHexString, isHexPrefixed } from 'ethjs-util'
 import { assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
 
+// These can be moved to './types' when PR#275 is merged.
+export interface TransformableToArray {
+  toArray(): Uint8Array
+  toBuffer?(): Buffer
+}
+export interface TransformableToBuffer {
+  toBuffer(): Buffer
+  toArray?(): Uint8Array
+}
+
 /**
  * Returns a buffer filled with 0s.
  * @param bytes the number of bytes the buffer should be
@@ -109,34 +119,58 @@ const stripZeros = function(a: any): Buffer | number[] | string {
  * Inputs supported: `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` or `toBuffer()` method.
  * @param v the value
  */
-export const toBuffer = function(v: any): Buffer {
-  if (!Buffer.isBuffer(v)) {
-    if (Array.isArray(v) || v instanceof Uint8Array) {
-      v = Buffer.from(v as Uint8Array)
-    } else if (typeof v === 'string') {
-      if (isHexString(v)) {
-        v = Buffer.from(padToEven(stripHexPrefix(v)), 'hex')
-      } else {
-        throw new Error(
-          `Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: ${v}`,
-        )
-      }
-    } else if (typeof v === 'number') {
-      v = intToBuffer(v)
-    } else if (v === null || v === undefined) {
-      v = Buffer.allocUnsafe(0)
-    } else if (BN.isBN(v)) {
-      v = v.toArrayLike(Buffer)
-    } else if (v.toArray) {
-      // converts a BN to a Buffer
-      v = Buffer.from(v.toArray())
-    } else if (v.toBuffer) {
-      v = Buffer.from(v.toBuffer())
-    } else {
-      throw new Error('invalid type')
-    }
+export const toBuffer = function(
+  v:
+    | string
+    | number
+    | BN
+    | Buffer
+    | Uint8Array
+    | number[]
+    | TransformableToArray
+    | TransformableToBuffer
+    | null
+    | undefined,
+): Buffer {
+  if (v === null || v === undefined) {
+    return Buffer.allocUnsafe(0)
   }
-  return v
+
+  if (Buffer.isBuffer(v)) {
+    return Buffer.from(v)
+  }
+
+  if (Array.isArray(v) || v instanceof Uint8Array) {
+    return Buffer.from(v as Uint8Array)
+  }
+
+  if (typeof v === 'string') {
+    if (!isHexString(v)) {
+      throw new Error(
+        `Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: ${v}`,
+      )
+    }
+    return Buffer.from(padToEven(stripHexPrefix(v)), 'hex')
+  }
+
+  if (typeof v === 'number') {
+    return intToBuffer(v)
+  }
+
+  if (BN.isBN(v)) {
+    return v.toArrayLike(Buffer)
+  }
+
+  if (v.toArray) {
+    // converts a BN to a Buffer
+    return Buffer.from(v.toArray())
+  }
+
+  if (v.toBuffer) {
+    return Buffer.from(v.toBuffer())
+  }
+
+  throw new Error('invalid type')
 }
 
 /**

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -105,7 +105,8 @@ const stripZeros = function(a: any): Buffer | number[] | string {
 }
 
 /**
- * Attempts to turn a value into a `Buffer`. As input it supports `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` method.
+ * Attempts to turn a value into a `Buffer`.
+ * Inputs supported: `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` or `toBuffer()` method.
  * @param v the value
  */
 export const toBuffer = function(v: any): Buffer {

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -1,16 +1,7 @@
 import * as BN from 'bn.js'
 import { intToBuffer, stripHexPrefix, padToEven, isHexString, isHexPrefixed } from 'ethjs-util'
+import { TransformableToArray, TransformableToBuffer } from './types'
 import { assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
-
-// These can be moved to './types' when PR#275 is merged.
-export interface TransformableToArray {
-  toArray(): Uint8Array
-  toBuffer?(): Buffer
-}
-export interface TransformableToBuffer {
-  toBuffer(): Buffer
-  toArray?(): Uint8Array
-}
 
 /**
  * Returns a buffer filled with 0s.

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -129,6 +129,8 @@ export const toBuffer = function(v: any): Buffer {
     } else if (v.toArray) {
       // converts a BN to a Buffer
       v = Buffer.from(v.toArray())
+    } else if (v.toBuffer) {
+      v = Buffer.from(v.toBuffer())
     } else {
       throw new Error('invalid type')
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,10 +24,19 @@ export type BufferLike =
 export type PrefixedHexString = string
 
 /*
+ * A type that represents an object that has a `toArray()` method.
+ */
+export interface TransformableToArray {
+  toArray(): Uint8Array
+  toBuffer?(): Buffer
+}
+
+/*
  * A type that represents an object that has a `toBuffer()` method.
  */
 export interface TransformableToBuffer {
   toBuffer(): Buffer
+  toArray?(): Uint8Array
 }
 
 /**

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -76,4 +76,12 @@ describe('Address', () => {
       assert.equal(addr.toString(), result)
     }
   })
+
+  it('should provide a buffer that does not mutate the original address', () => {
+    const str = '0x2f015c60e0be116b1f0cd534704db9c92118fb6a'
+    const address = Address.fromString(str)
+    let addressBuf = address.toBuffer()
+    addressBuf = Buffer.from('test')
+    assert.equal(address.toString(), str)
+  })
 })

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -80,8 +80,8 @@ describe('Address', () => {
   it('should provide a buffer that does not mutate the original address', () => {
     const str = '0x2f015c60e0be116b1f0cd534704db9c92118fb6a'
     const address = Address.fromString(str)
-    let addressBuf = address.toBuffer()
-    addressBuf = Buffer.from('test')
+    const addressBuf = address.toBuffer()
+    addressBuf.fill(0)
     assert.equal(address.toString(), str)
   })
 })

--- a/test/bytes.spec.ts
+++ b/test/bytes.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import * as BN from 'bn.js'
 import {
+  Address,
   zeros,
   zeroAddress,
   isZeroAddress,
@@ -232,6 +233,13 @@ describe('toBuffer', function() {
     assert.throws(() => toBuffer('11'), '11')
     assert.throws(() => toBuffer(''))
     assert.throws(() => toBuffer('0xR'), '0xR')
+  })
+
+  it('should convert a TransformableToBuffer like the Address class (i.e. provides a toBuffer method)', function() {
+    const str = '0x2f015c60e0be116b1f0cd534704db9c92118fb6a'
+    const address = Address.fromString(str)
+    const addressBuf = toBuffer(address)
+    assert.ok(addressBuf.equals(address.toBuffer()))
   })
 })
 

--- a/test/bytes.spec.ts
+++ b/test/bytes.spec.ts
@@ -216,7 +216,7 @@ describe('toBuffer', function() {
     // 'toArray'
     assert.deepEqual(
       toBuffer({
-        toArray: function() {
+        toArray: function(): any {
           return [1]
         },
       }),
@@ -225,6 +225,7 @@ describe('toBuffer', function() {
   })
   it('should fail', function() {
     assert.throws(function() {
+      // @ts-ignore
       toBuffer({ test: 1 })
     })
   })


### PR DESCRIPTION
This PR adds a `toBuffer()` method to Address, and makes the exported `toBuffer()` function additionally handle if the object has a `toBuffer()` method.

This work was motivated by @jochem-brouwer's work in the block library refactoring [(thread here)](https://github.com/ethereumjs/ethereumjs-vm/pull/883#discussion_r496211455).