### PR TITLE
Update Account.isEmpty to be EIP-161 compliant / New v7.0.7 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [7.0.7] - 2020-10-15
 
-- Removed `stateRoot` check for `Account.isEmpty()` to make emptiness check `EIP-161` compliant,
-  PR [#279](https://github.com/ethereumjs/ethereumjs-util/pull/279)
+- Removed `stateRoot` check for `Account.isEmpty()` to make emptiness check `EIP-161` compliant, PR [#279](https://github.com/ethereumjs/ethereumjs-util/pull/279)
+- Added type `AddressLike` and helper `bnToHex()`, PR [#279](https://github.com/ethereumjs/ethereumjs-util/pull/279)
+- Added `account.raw()` which returns a Buffer Array of the raw Buffers for the account in order, PR [#279](https://github.com/ethereumjs/ethereumjs-util/pull/279)
 
 [7.0.7]: https://github.com/ethereumjs/ethereumjs-util/compare/v7.0.6...v7.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.7] - 2020-10-15
+
+- Removed `stateRoot` check for `Account.isEmpty()` to make emptiness check `EIP-161` compliant,
+  PR [#279](https://github.com/ethereumjs/ethereumjs-util/pull/279)
+
+[7.0.7]: https://github.com/ethereumjs/ethereumjs-util/compare/v7.0.6...v7.0.7
+
 ## [7.0.6] - 2020-10-07
 
 ### New `Account` class

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-util",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "a collection of utility functions for Ethereum",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/account.ts
+++ b/src/account.ts
@@ -108,17 +108,12 @@ export class Account {
   }
 
   /**
-   * Returns a `Boolean` determining if the account is empty.
-   * For more details about account emptiness see [EIP-161](https://eips.ethereum.org/EIPS/eip-161).
-   * Note: The stateRoot is also checked to be empty since in Frontier it was possible to create a contract with no code where nonce remained 0 but some values were written to storage in the constructor (thus stateRoot is not KECCAK256_RLP).
+   * Returns a `Boolean` determining if the account is empty complying to the definition of
+   * account emptiness in [EIP-161](https://eips.ethereum.org/EIPS/eip-161):
+   * "An account is considered empty when it has no code and zero nonce and zero balance."
    */
   isEmpty(): boolean {
-    return (
-      this.balance.isZero() &&
-      this.nonce.isZero() &&
-      this.stateRoot.equals(KECCAK256_RLP) &&
-      this.codeHash.equals(KECCAK256_NULL)
-    )
+    return this.balance.isZero() && this.nonce.isZero() && this.codeHash.equals(KECCAK256_NULL)
   }
 }
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -94,10 +94,17 @@ export class Account {
   }
 
   /**
+   * Returns a Buffer Array of the raw Buffers for the account, in order.
+   */
+  raw(): Buffer[] {
+    return [bnToRlp(this.nonce), bnToRlp(this.balance), this.stateRoot, this.codeHash]
+  }
+
+  /**
    * Returns the RLP serialization of the account as a `Buffer`.
    */
   serialize(): Buffer {
-    return rlp.encode([bnToRlp(this.nonce), bnToRlp(this.balance), this.stateRoot, this.codeHash])
+    return rlp.encode(this.raw())
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as BN from 'bn.js'
+import { Address } from './address'
 import { unpadBuffer } from './bytes'
 
 /*
@@ -23,6 +24,12 @@ export type BufferLike =
  */
 export type PrefixedHexString = string
 
+/**
+ * A type that represents an Address-like value.
+ * To convert to address, use `new Address(toBuffer(value))`
+ */
+export type AddressLike = Address | Buffer | string
+
 /*
  * A type that represents an object that has a `toArray()` method.
  */
@@ -37,6 +44,13 @@ export interface TransformableToArray {
 export interface TransformableToBuffer {
   toBuffer(): Buffer
   toArray?(): Uint8Array
+}
+
+/**
+ * Convert BN to 0x-prefixed hex string.
+ */
+export function bnToHex(value: BN): PrefixedHexString {
+  return `0x${value.toString(16)}`
 }
 
 /**


### PR DESCRIPTION
This PR updates `Account.isEmpty()` to be `EIP-161` compliant (the `stateRoot` check is therefore removed) following the result of the discussion along the `Util.Account` integration PR [here](https://github.com/ethereumjs/ethereumjs-vm/pull/911/files/633255ea58d3916517b8b077c763f30a19b4238f#r504602050) within the VM and the monorepo libraries in general.