### PR TITLE
Handle signatures for chainIds greater than 110

### DIFF
--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,6 +1,6 @@
 const { ecdsaSign, ecdsaRecover, publicKeyConvert } = require('ethereum-cryptography/secp256k1')
 import * as BN from 'bn.js'
-import { toBuffer, setLengthLeft, bufferToHex } from './bytes'
+import { toBuffer, setLengthLeft, bufferToHex, bufferToInt } from './bytes'
 import { keccak } from './hash'
 import { assertIsBuffer } from './helpers'
 
@@ -71,12 +71,11 @@ export const toRpcSig = function(v: number, r: Buffer, s: Buffer, chainId?: numb
 export const fromRpcSig = function(sig: string): ECDSASignature {
   const buf: Buffer = toBuffer(sig)
 
-  // NOTE: with potential introduction of chainId this might need to be updated
-  if (buf.length !== 65) {
+  if (buf.length < 65) {
     throw new Error('Invalid signature length')
   }
 
-  let v = buf[64]
+  let v = bufferToInt(buf.slice(64))
   // support both versions of `eth_sign` responses
   if (v < 27) {
     v += 27


### PR DESCRIPTION
The signature module was assuming that the `v` recovery value fit in a single byte. With chainIds larger than 110, since `v(110) = 110 * 2 + 35 = 255`, this assumption breaks (see chainid.network for a list of chainIds with large values).

This commit changes `fromRpcSig` so the recovery `v` value is not just the 65th byte of the signaure, but all bytes after the 64th.