### PR TITLE
Upgrade to ethereumjs-config v2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: '@ethereumjs/eslint-config-defaults',
+  env: {
+    mocha: true
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm install
       - run: npm run test
 
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@master
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.node-version == 12 }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./coverage/lcov.info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,6 @@ jobs:
       - run: npm run test
 
       - uses: codecov/codecov-action@v1
-        if: ${{ matrix.node-version == 12 }}
+        if: matrix.node-version == '12.x'
         with:
           file: ./coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SYNOPSIS
 
-[![NPM Package](https://img.shields.io/npm/v/ethereumjs-util.svg)](https://www.npmjs.org/package/ethereumjs-util)
-[![Actions Status](https://github.com/ethereumjs/ethereumjs-util/workflows/Build/badge.svg)](https://github.com/ethereumjs/ethereumjs-util/actions)
-[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-util.svg)](https://coveralls.io/r/ethereumjs/ethereumjs-util)
+[![NPM Status][npm-badge]][npm-link]
+[![Actions Status][actions-badge]][actions-link]
+[![Coverage Status][coverage-badge]][coverage-link]
 [![Discord][discord-badge]][discord-link]
 
 A collection of utility functions for Ethereum. It can be used in Node.js and in the browser with [browserify](http://browserify.org/).
@@ -71,7 +71,7 @@ The following methods are available provided by [ethjs-util](https://github.com/
 - toAscii
 - getKeys
 
-Import can be done directly by function name analogous to the build-in function import:
+They can be imported by name:
 
 ```js
 import { intToHex, stripHexPrefix } from 'ethereumjs-util'
@@ -94,5 +94,11 @@ If you want to join for work or do improvements on the libraries have a look at 
 
 MPL-2.0
 
+[npm-badge]: https://img.shields.io/npm/v/ethereumjs-util.svg
+[npm-link]: https://www.npmjs.org/package/ethereumjs-util
+[actions-badge]: https://github.com/ethereumjs/ethereumjs-util/workflows/Build/badge.svg
+[actions-link]: https://github.com/ethereumjs/ethereumjs-util/actions
+[coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-util/branch/master/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-util
 [discord-badge]: https://img.shields.io/static/v1?logo=discord&label=discord&message=Join&color=blue
 [discord-link]: https://discord.gg/TNwARpR

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        base: auto

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,16 +1,16 @@
 module.exports = function(config) {
   config.set({
     frameworks: ['mocha', 'karma-typescript'],
-    exclude: ["src/@types/**"],  // ref: https://github.com/monounity/karma-typescript/issues/254
     files: ['src/**/*.ts', 'test/**/*.ts'],
     preprocessors: {
-      '**/*.ts': ['karma-typescript'],
+      '**/*.ts': ['karma-typescript']
     },
     plugins: ['karma-mocha', 'karma-typescript', 'karma-chrome-launcher', 'karma-firefox-launcher'],
     karmaTypescriptConfig: {
       bundlerOptions: {
-        entrypoints: /\.spec\.ts$/,
+        entrypoints: /\.spec\.ts$/
       },
+      tsconfig: './tsconfig.json'
     },
     colors: true,
     reporters: ['progress', 'karma-typescript'],
@@ -19,6 +19,6 @@ module.exports = function(config) {
     concurrency: Infinity,
     // Fail after timeout
     browserDisconnectTimeout: 100000,
-    browserNoActivityTimeout: 100000,
+    browserNoActivityTimeout: 100000
   })
 }

--- a/package.json
+++ b/package.json
@@ -11,19 +11,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "ethereumjs-config-build",
+    "build": "ethereumjs-config-ts-build",
     "prepublishOnly": "npm run test && npm run build",
     "docs:build": "npx typedoc --options typedoc.js",
-    "format": "ethereumjs-config-format",
-    "format:fix": "ethereumjs-config-format-fix",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
     "test": "npm run lint && npm run test:node && npm run test:browser",
     "test:browser": "karma start karma.conf.js",
     "test:node": "nyc --reporter=lcov mocha --require ts-node/register 'test/*.spec.ts'",
-    "tsc": "ethereumjs-config-tsc",
-    "tslint": "ethereumjs-config-tslint",
-    "tslint:fix": "ethereumjs-config-tslint-fix"
+    "tsc": "ethereumjs-config-tsc"
   },
   "husky": {
     "hooks": {
@@ -89,7 +85,7 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-util",
   "dependencies": {
-    "@types/bn.js": "^4.11.3",
+    "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2",
     "create-hash": "^1.1.2",
     "ethereum-cryptography": "^0.1.3",
@@ -97,10 +93,11 @@
     "rlp": "^2.2.4"
   },
   "devDependencies": {
-    "@ethereumjs/config-prettier": "^1.1.0",
-    "@ethereumjs/config-tsc": "^1.1.0",
-    "@ethereumjs/config-tslint": "^1.1.0",
-    "@types/mocha": "^5.2.7",
+    "@ethereumjs/config-coverage": "^2.0.0",
+    "@ethereumjs/config-typescript": "^2.0.0",
+    "@ethereumjs/eslint-config-defaults": "^2.0.0",
+    "@types/assert": "^1.5.4",
+    "@types/mocha": "^8.2.0",
     "@types/node": "^11.9.0",
     "@types/secp256k1": "^4.0.1",
     "husky": "^2.1.0",
@@ -109,14 +106,12 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^2.0.0",
     "karma-typescript": "^4.1.1",
-    "mocha": "^6.0.0",
+    "mocha": "^8.2.1",
     "nyc": "^15.0.0",
     "prettier": "^1.15.3",
     "ts-node": "^8.6.2",
-    "tslint": "^5.12.0",
     "typedoc": "next",
     "typedoc-plugin-markdown": "^2.2.16",
-    "typescript": "^3.8.3",
-    "typestrict": "^1.0.2"
+    "typescript": "^3.8.3"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@ethereumjs/config-prettier')
+module.exports = require('@ethereumjs/eslint-config-defaults/prettier.config.js')

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert'
-import * as BN from 'bn.js'
+import assert from 'assert'
+import BN from 'bn.js'
 import * as rlp from 'rlp'
 import { stripHexPrefix } from 'ethjs-util'
 import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
@@ -12,7 +12,7 @@ const {
   privateKeyVerify,
   publicKeyCreate,
   publicKeyVerify,
-  publicKeyConvert,
+  publicKeyConvert
 } = require('ethereum-cryptography/secp256k1')
 
 export interface AccountData {
@@ -35,7 +35,7 @@ export class Account {
       nonce ? new BN(toBuffer(nonce)) : undefined,
       balance ? new BN(toBuffer(balance)) : undefined,
       stateRoot ? toBuffer(stateRoot) : undefined,
-      codeHash ? toBuffer(codeHash) : undefined,
+      codeHash ? toBuffer(codeHash) : undefined
     )
   }
 
@@ -52,12 +52,7 @@ export class Account {
   public static fromValuesArray(values: Buffer[]) {
     const [nonce, balance, stateRoot, codeHash] = values
 
-    return new Account(
-      nonce ? new BN(nonce) : undefined,
-      balance ? new BN(balance) : undefined,
-      stateRoot,
-      codeHash,
-    )
+    return new Account(new BN(nonce), new BN(balance), stateRoot, codeHash)
   }
 
   /**
@@ -68,7 +63,7 @@ export class Account {
     nonce = new BN(0),
     balance = new BN(0),
     stateRoot = KECCAK256_RLP,
-    codeHash = KECCAK256_NULL,
+    codeHash = KECCAK256_NULL
   ) {
     this.nonce = nonce
     this.balance = balance
@@ -169,7 +164,7 @@ export const toChecksumAddress = function(hexAddress: string, eip1191ChainId?: n
  */
 export const isValidChecksumAddress = function(
   hexAddress: string,
-  eip1191ChainId?: number,
+  eip1191ChainId?: number
 ): boolean {
   return isValidAddress(hexAddress) && toChecksumAddress(hexAddress, eip1191ChainId) === hexAddress
 }
@@ -209,7 +204,7 @@ export const generateAddress2 = function(from: Buffer, salt: Buffer, initCode: B
   assert(salt.length === 32)
 
   const address = keccak256(
-    Buffer.concat([Buffer.from('ff', 'hex'), from, salt, keccak256(initCode)]),
+    Buffer.concat([Buffer.from('ff', 'hex'), from, salt, keccak256(initCode)])
   )
 
   return address.slice(-20)
@@ -260,14 +255,6 @@ export const pubToAddress = function(pubKey: Buffer, sanitize: boolean = false):
 export const publicToAddress = pubToAddress
 
 /**
- * Returns the ethereum address of a given private key.
- * @param privateKey A private key must be 256 bits wide
- */
-export const privateToAddress = function(privateKey: Buffer): Buffer {
-  return publicToAddress(privateToPublic(privateKey))
-}
-
-/**
  * Returns the ethereum public key of a given private key.
  * @param privateKey A private key must be 256 bits wide
  */
@@ -275,6 +262,14 @@ export const privateToPublic = function(privateKey: Buffer): Buffer {
   assertIsBuffer(privateKey)
   // skip the type flag and use the X, Y points
   return Buffer.from(publicKeyCreate(privateKey, false)).slice(1)
+}
+
+/**
+ * Returns the ethereum address of a given private key.
+ * @param privateKey A private key must be 256 bits wide
+ */
+export const privateToAddress = function(privateKey: Buffer): Buffer {
+  return publicToAddress(privateToPublic(privateKey))
 }
 
 /**

--- a/src/address.ts
+++ b/src/address.ts
@@ -6,7 +6,7 @@ import {
   pubToAddress,
   privateToAddress,
   generateAddress,
-  generateAddress2,
+  generateAddress2
 } from './account'
 
 export class Address {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,12 @@
 const Buffer = require('buffer').Buffer
-import * as BN from 'bn.js'
+import BN from 'bn.js'
 
 /**
  * The max integer that this VM can handle
  */
 export const MAX_INTEGER: BN = new BN(
   'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-  16,
+  16
 )
 
 /**
@@ -14,7 +14,7 @@ export const MAX_INTEGER: BN = new BN(
  */
 export const TWO_POW256: BN = new BN(
   '10000000000000000000000000000000000000000000000000000000000000000',
-  16,
+  16
 )
 
 /**

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,6 +1,5 @@
 const { keccak224, keccak384, keccak256: k256, keccak512 } = require('ethereum-cryptography/keccak')
 const createHash = require('create-hash')
-import * as ethjsUtil from 'ethjs-util'
 import * as rlp from 'rlp'
 import { toBuffer, setLengthLeft } from './bytes'
 import { assertIsString, assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
@@ -71,6 +70,17 @@ export const keccakFromArray = function(a: number[], bits: number = 256) {
 }
 
 /**
+ * Creates SHA256 hash of an input.
+ * @param  a The input data (Buffer|Array|String)
+ */
+const _sha256 = function(a: any): Buffer {
+  a = toBuffer(a)
+  return createHash('sha256')
+    .update(a)
+    .digest()
+}
+
+/**
  * Creates SHA256 hash of a Buffer input.
  * @param a The input data (Buffer)
  */
@@ -98,14 +108,20 @@ export const sha256FromArray = function(a: number[]): Buffer {
 }
 
 /**
- * Creates SHA256 hash of an input.
- * @param  a The input data (Buffer|Array|String)
+ * Creates RIPEMD160 hash of the input.
+ * @param a The input data (Buffer|Array|String|Number)
+ * @param padded Whether it should be padded to 256 bits or not
  */
-const _sha256 = function(a: any): Buffer {
+const _ripemd160 = function(a: any, padded: boolean): Buffer {
   a = toBuffer(a)
-  return createHash('sha256')
+  const hash = createHash('rmd160')
     .update(a)
     .digest()
+  if (padded === true) {
+    return setLengthLeft(hash, 32)
+  } else {
+    return hash
+  }
 }
 
 /**
@@ -136,23 +152,6 @@ export const ripemd160FromString = function(a: string, padded: boolean): Buffer 
 export const ripemd160FromArray = function(a: number[], padded: boolean): Buffer {
   assertIsArray(a)
   return _ripemd160(a, padded)
-}
-
-/**
- * Creates RIPEMD160 hash of the input.
- * @param a The input data (Buffer|Array|String|Number)
- * @param padded Whether it should be padded to 256 bits or not
- */
-const _ripemd160 = function(a: any, padded: boolean): Buffer {
-  a = toBuffer(a)
-  const hash = createHash('rmd160')
-    .update(a)
-    .digest()
-  if (padded === true) {
-    return setLengthLeft(hash, 32)
-  } else {
-    return hash
-  }
 }
 
 /**

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,5 +1,5 @@
+import assert from 'assert'
 import * as ethjsUtil from 'ethjs-util'
-import * as assert from 'assert'
 import * as rlp from 'rlp'
 import { toBuffer, baToJSON, unpadBuffer } from './bytes'
 
@@ -51,12 +51,12 @@ export const defineProperties = function(self: any, fields: any, data?: any) {
         v = unpadBuffer(v)
         assert(
           field.length >= v.length,
-          `The field ${field.name} must not have more ${field.length} bytes`,
+          `The field ${field.name} must not have more ${field.length} bytes`
         )
       } else if (!(field.allowZero && v.length === 0) && field.length) {
         assert(
           field.length === v.length,
-          `The field ${field.name} must have byte length of ${field.length}`,
+          `The field ${field.name} must have byte length of ${field.length}`
         )
       }
 
@@ -67,7 +67,7 @@ export const defineProperties = function(self: any, fields: any, data?: any) {
       enumerable: true,
       configurable: true,
       get: getter,
-      set: setter,
+      set: setter
     })
 
     if (field.default) {
@@ -80,7 +80,7 @@ export const defineProperties = function(self: any, fields: any, data?: any) {
         enumerable: false,
         configurable: true,
         set: setter,
-        get: getter,
+        get: getter
       })
     }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as BN from 'bn.js'
+import BN from 'bn.js'
 import { Address } from './address'
 import { unpadBuffer } from './bytes'
 

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert'
-import * as BN from 'bn.js'
+import assert from 'assert'
+import BN from 'bn.js'
 import * as rlp from 'rlp'
 import {
   Account,
@@ -14,7 +14,7 @@ import {
   toBuffer,
   isValidChecksumAddress,
   isValidAddress,
-  toChecksumAddress,
+  toChecksumAddress
 } from '../src'
 const eip1014Testdata = require('./testdata/eip1014Examples.json')
 
@@ -30,13 +30,13 @@ describe('Account', function() {
     it('should have stateRoot equal to KECCAK256_RLP', function() {
       assert.ok(
         account.stateRoot.toString('hex'),
-        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
       )
     })
     it('should have codeHash equal to KECCAK256_NULL', function() {
       assert.equal(
         account.codeHash.toString('hex'),
-        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
       )
     })
   })
@@ -46,7 +46,7 @@ describe('Account', function() {
       '0x02', // nonce
       '0x0384', // balance
       '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421', // stateRoot
-      '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470', // codeHash
+      '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470' // codeHash
     ]
     const account = Account.fromValuesArray(raw.map(toBuffer))
     it('should have correct nonce', function() {
@@ -58,13 +58,13 @@ describe('Account', function() {
     it('should have correct stateRoot', function() {
       assert.equal(
         account.stateRoot.toString('hex'),
-        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
       )
     })
     it('should have correct codeHash', function() {
       assert.equal(
         account.codeHash.toString('hex'),
-        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
       )
     })
   })
@@ -74,7 +74,7 @@ describe('Account', function() {
       nonce: '0x02',
       balance: '0x0384',
       stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-      codeHash: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+      codeHash: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
     }
     const account = Account.fromAccountData(raw)
     it('should have correct nonce', function() {
@@ -86,13 +86,13 @@ describe('Account', function() {
     it('should have correct stateRoot', function() {
       assert.equal(
         account.stateRoot.toString('hex'),
-        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
       )
     })
     it('should have correct codeHash', function() {
       assert.equal(
         account.codeHash.toString('hex'),
-        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
       )
     })
   })
@@ -100,7 +100,7 @@ describe('Account', function() {
   describe('from RLP data', function() {
     const accountRlp = Buffer.from(
       'f84602820384a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
-      'hex',
+      'hex'
     )
     const account = Account.fromRlpSerializedAccount(accountRlp)
     it('should have correct nonce', function() {
@@ -112,13 +112,13 @@ describe('Account', function() {
     it('should have correct stateRoot', function() {
       assert.equal(
         account.stateRoot.toString('hex'),
-        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+        '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
       )
     })
     it('should have correct codeHash', function() {
       assert.equal(
         account.codeHash.toString('hex'),
-        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
       )
     })
   })
@@ -128,7 +128,7 @@ describe('Account', function() {
       nonce: '0x01',
       balance: '0x42',
       stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-      codeHash: '0xc5d2461236f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+      codeHash: '0xc5d2461236f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
     }
     const account = Account.fromAccountData(raw)
     const accountRlp = rlp.encode([raw.nonce, raw.balance, raw.stateRoot, raw.codeHash])
@@ -141,7 +141,7 @@ describe('Account', function() {
     it('should return false for a non-contract account', function() {
       const accountRlp = Buffer.from(
         'f84602820384a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
-        'hex',
+        'hex'
       )
       const account = Account.fromRlpSerializedAccount(accountRlp)
       assert.equal(account.isContract(), false)
@@ -152,7 +152,7 @@ describe('Account', function() {
         nonce: '0x01',
         balance: '0x0042',
         stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-        codeHash: '0xc5d2461236f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        codeHash: '0xc5d2461236f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
       }
       const account = Account.fromAccountData(raw)
       assert.ok(account.isContract())
@@ -170,7 +170,7 @@ describe('Account', function() {
         nonce: '0x01',
         balance: '0x0042',
         stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-        codeHash: '0xd748bf26ab37599c944babfdbeecf6690801bd61bf2670efb0a34adfc6dca10b',
+        codeHash: '0xd748bf26ab37599c944babfdbeecf6690801bd61bf2670efb0a34adfc6dca10b'
       }
       const account = Account.fromAccountData(raw)
       assert.equal(account.isEmpty(), false)
@@ -253,56 +253,56 @@ describe('isValidPublic', function() {
   it('should fail on too short input', function() {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae744',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey), false)
   })
   it('should fail on too big input', function() {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d00',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey), false)
   })
   it('should fail on SEC1 key', function() {
     const pubKey = Buffer.from(
       '043a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey), false)
   })
   it("shouldn't fail on SEC1 key with sanitize enabled", function() {
     const pubKey = Buffer.from(
       '043a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey, true), true)
   })
   it('should fail with an invalid SEC1 public key', function() {
     const pubKey = Buffer.from(
       '023a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey, true), false)
   })
   it('should work with compressed keys with sanitize enabled', function() {
     const pubKey = Buffer.from(
       '033a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey, true), true)
   })
   it('should work with sanitize enabled', function() {
     const pubKey = Buffer.from(
       '043a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey, true), true)
   })
   it('should work otherwise', function() {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.equal(isValidPublic(pubKey), true)
   })
@@ -345,7 +345,7 @@ describe('publicToAddress', function() {
   it('should produce an address given a public key', function() {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     const address = '2f015c60e0be116b1f0cd534704db9c92118fb6a'
     const r = publicToAddress(pubKey)
@@ -354,7 +354,7 @@ describe('publicToAddress', function() {
   it('should produce an address given a SEC1 public key', function() {
     const pubKey = Buffer.from(
       '043a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     const address = '2f015c60e0be116b1f0cd534704db9c92118fb6a'
     const r = publicToAddress(pubKey, true)
@@ -363,7 +363,7 @@ describe('publicToAddress', function() {
   it("shouldn't produce an address given an invalid SEC1 public key", function() {
     const pubKey = Buffer.from(
       '023a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     assert.throws(function() {
       publicToAddress(pubKey, true)
@@ -372,7 +372,7 @@ describe('publicToAddress', function() {
   it("shouldn't produce an address given an invalid public key", function() {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae744',
-      'hex',
+      'hex'
     )
     assert.throws(function() {
       publicToAddress(pubKey)
@@ -393,7 +393,7 @@ describe('privateToPublic', function() {
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d'
     const privateKey = Buffer.from(
       'ea54bdc52d163f88c93ab0615782cf718a2efb9e51a7989aab1b08067e9c1c5f',
-      'hex',
+      'hex'
     )
     const r: any = privateToPublic(privateKey).toString('hex')
     assert.equal(r.toString('hex'), pubKey)
@@ -401,11 +401,11 @@ describe('privateToPublic', function() {
   it("shouldn't produce a public key given an invalid private key", function() {
     const privateKey1 = Buffer.from(
       'ea54bdc52d163f88c93ab0615782cf718a2efb9e51a7989aab1b08067e9c1c5f2a',
-      'hex',
+      'hex'
     )
     const privateKey2 = Buffer.from(
       'ea54bdc52d163f88c93ab0615782cf718a2efb9e51a7989aab1b08067e9c1c',
-      'hex',
+      'hex'
     )
     assert.throws(function() {
       privateToPublic(privateKey1)
@@ -432,7 +432,7 @@ describe('privateToAddress', function() {
     // Our private key
     const privateKey = Buffer.from(
       'ea54bdc52d163f88c93ab0615782cf718a2efb9e51a7989aab1b08067e9c1c5f',
-      'hex',
+      'hex'
     )
     const r: any = privateToAddress(privateKey).toString('hex')
     assert.equal(r.toString('hex'), address)
@@ -443,7 +443,7 @@ describe('generateAddress', function() {
   it('should produce an address given a public key', function() {
     const add: any = generateAddress(
       Buffer.from('990ccf8a0de58091c028d6ff76bb235ee67c1c39', 'utf8'),
-      toBuffer(14),
+      toBuffer(14)
     ).toString('hex')
     assert.equal(add.toString('hex'), '936a4295d8d74e310c0c95f0a63e53737b998d12')
   })
@@ -453,7 +453,7 @@ describe('generateAddress with hex prefix', function() {
   it('should produce an address given a public key', function() {
     const add: any = generateAddress(
       toBuffer('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39'),
-      toBuffer(14),
+      toBuffer(14)
     ).toString('hex')
     assert.equal(add.toString('hex'), 'd658a4b8247c14868f3c512fa5cbb6e458e4a989')
   })
@@ -463,7 +463,7 @@ describe('generateAddress with nonce 0 (special case)', function() {
   it('should produce an address given a public key', function() {
     const add: any = generateAddress(
       toBuffer('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39'),
-      toBuffer(0),
+      toBuffer(0)
     ).toString('hex')
     assert.equal(add.toString('hex'), 'bfa69ba91385206bfdd2d8b9c1a5d6c10097a85b')
   })
@@ -474,7 +474,7 @@ describe('generateAddress with non-buffer inputs', function() {
     assert.throws(function() {
       generateAddress(
         (<unknown>'0x990ccf8a0de58091c028d6ff76bb235ee67c1c39') as Buffer,
-        toBuffer(0),
+        toBuffer(0)
       )
     })
   })
@@ -482,7 +482,7 @@ describe('generateAddress with non-buffer inputs', function() {
     assert.throws(function() {
       generateAddress(
         toBuffer('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39'),
-        (<unknown>0) as Buffer,
+        (<unknown>0) as Buffer
       )
     })
   })
@@ -490,12 +490,12 @@ describe('generateAddress with non-buffer inputs', function() {
 
 describe('generateAddress2: EIP-1014 testdata examples', function() {
   for (let i = 0; i <= 6; i++) {
-    let e = eip1014Testdata[i]
+    const e = eip1014Testdata[i]
     it(`${e['comment']}: should generate the addresses provided`, function() {
-      let result = generateAddress2(
+      const result = generateAddress2(
         toBuffer(e['address']),
         toBuffer(e['salt']),
-        toBuffer(e['initCode']),
+        toBuffer(e['initCode'])
       )
       assert.equal('0x' + result.toString('hex'), e['result'])
     })
@@ -510,7 +510,7 @@ describe('generateAddress2: non-buffer inputs', function() {
       generateAddress2(
         (<unknown>e['address']) as Buffer,
         toBuffer(e['salt']),
-        toBuffer(e['initCode']),
+        toBuffer(e['initCode'])
       )
     })
   })
@@ -519,7 +519,7 @@ describe('generateAddress2: non-buffer inputs', function() {
       generateAddress2(
         toBuffer(e['address']),
         (<unknown>e['salt']) as Buffer,
-        toBuffer(e['initCode']),
+        toBuffer(e['initCode'])
       )
     })
   })
@@ -528,7 +528,7 @@ describe('generateAddress2: non-buffer inputs', function() {
       generateAddress2(
         toBuffer(e['address']),
         toBuffer(e['salt']),
-        (<unknown>e['initCode']) as Buffer,
+        (<unknown>e['initCode']) as Buffer
       )
     })
   })
@@ -545,7 +545,7 @@ const eip55ChecksumAddresses = [
   '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
   '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
   '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
-  '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+  '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'
 ]
 
 const eip1191ChecksummAddresses = {
@@ -558,7 +558,7 @@ const eip1191ChecksummAddresses = {
     '0xd1220a0CF47C7B9Be7A2E6ba89F429762E7B9Adb',
     '0xdBf03b407c01e7cD3CBea99509d93f8dDDC8C6fB',
     '0xDe709F2102306220921060314715629080E2fb77',
-    '0xfb6916095Ca1dF60bB79cE92ce3ea74C37c5D359',
+    '0xfb6916095Ca1dF60bB79cE92ce3ea74C37c5D359'
   ],
   30: [
     '0x6549F4939460DE12611948B3F82B88C3C8975323',
@@ -570,7 +570,7 @@ const eip1191ChecksummAddresses = {
     '0xD1220A0Cf47c7B9BE7a2e6ba89F429762E7B9adB',
     '0xDBF03B407c01E7CD3cBea99509D93F8Dddc8C6FB',
     '0xDe709F2102306220921060314715629080e2FB77',
-    '0xFb6916095cA1Df60bb79ce92cE3EA74c37c5d359',
+    '0xFb6916095cA1Df60bb79ce92cE3EA74c37c5d359'
   ],
   31: [
     '0x42712D45473476B98452F434E72461577D686318',
@@ -583,15 +583,15 @@ const eip1191ChecksummAddresses = {
     '0xDE709F2102306220921060314715629080e2Fb77',
     '0xFb6916095CA1dF60bb79CE92ce3Ea74C37c5D359',
     '0xd1220a0CF47c7B9Be7A2E6Ba89f429762E7b9adB',
-    '0xdbF03B407C01E7cd3cbEa99509D93f8dDDc8C6fB',
-  ],
+    '0xdbF03B407C01E7cd3cbEa99509D93f8dDDc8C6fB'
+  ]
 }
 
 describe('.toChecksumAddress()', function() {
   describe('EIP55', function() {
     it('should work', function() {
       for (let i = 0; i < eip55ChecksumAddresses.length; i++) {
-        let tmp = eip55ChecksumAddresses[i]
+        const tmp = eip55ChecksumAddresses[i]
         assert.equal(toChecksumAddress(tmp.toLowerCase()), tmp)
       }
     })

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+import assert from 'assert'
 import { BN, toBuffer } from '../src'
 import { Address } from '../src'
 const eip1014Testdata = require('./testdata/eip1014Examples.json')
@@ -36,7 +36,7 @@ describe('Address', () => {
   it('should instantiate from public key', () => {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
-      'hex',
+      'hex'
     )
     const str = '0x2f015c60e0be116b1f0cd534704db9c92118fb6a'
     const addr = Address.fromPublicKey(pubKey)
@@ -46,7 +46,7 @@ describe('Address', () => {
   it('should fail to instantiate from invalid public key', () => {
     const pubKey = Buffer.from(
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae744',
-      'hex',
+      'hex'
     )
     assert.throws(() => Address.fromPublicKey(pubKey))
   })

--- a/test/bytes.spec.ts
+++ b/test/bytes.spec.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert'
-import * as BN from 'bn.js'
+import assert from 'assert'
+import BN from 'bn.js'
 import {
   Address,
   zeros,
@@ -16,7 +16,7 @@ import {
   toUnsigned,
   addHexPrefix,
   toBuffer,
-  baToJSON,
+  baToJSON
 } from '../src'
 
 describe('zeros function', function() {
@@ -218,9 +218,9 @@ describe('toBuffer', function() {
       toBuffer({
         toArray: function(): any {
           return [1]
-        },
+        }
       }),
-      Buffer.from([1]),
+      Buffer.from([1])
     )
   })
   it('should fail', function() {

--- a/test/constants.spec.ts
+++ b/test/constants.spec.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+import assert from 'assert'
 import {
   MAX_INTEGER,
   TWO_POW256,
@@ -7,49 +7,49 @@ import {
   KECCAK256_RLP_ARRAY_S,
   KECCAK256_RLP_ARRAY,
   KECCAK256_RLP_S,
-  KECCAK256_RLP,
+  KECCAK256_RLP
 } from '../src'
 
 describe('constants', function() {
   it('should match constants', function() {
     assert.equal(
       MAX_INTEGER.toString('hex'),
-      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
     )
 
     assert.equal(
       TWO_POW256.toString('hex'),
-      '10000000000000000000000000000000000000000000000000000000000000000',
+      '10000000000000000000000000000000000000000000000000000000000000000'
     )
 
     assert.equal(
       KECCAK256_NULL_S,
-      'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+      'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
     )
 
     assert.equal(
       KECCAK256_NULL.toString('hex'),
-      'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+      'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
     )
 
     assert.equal(
       KECCAK256_RLP_ARRAY_S,
-      '1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
+      '1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'
     )
 
     assert.equal(
       KECCAK256_RLP_ARRAY.toString('hex'),
-      '1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
+      '1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'
     )
 
     assert.equal(
       KECCAK256_RLP_S,
-      '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+      '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
     )
 
     assert.equal(
       KECCAK256_RLP.toString('hex'),
-      '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+      '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
     )
   })
 })

--- a/test/externals.spec.ts
+++ b/test/externals.spec.ts
@@ -1,6 +1,6 @@
-import * as assert from 'assert'
+import assert from 'assert'
 
-import * as BN_export from 'bn.js'
+import BN_export from 'bn.js'
 import * as rlp_export from 'rlp'
 
 import * as src from '../src'
@@ -43,8 +43,8 @@ describe('External rlp export', () => {
 
   it('should use a rlp function correctly', () => {
     const nestedList = [[], [[]], [[], [[]]]]
-    var encoded = src.rlp.encode(nestedList)
-    var decoded = src.rlp.decode(encoded)
+    const encoded = src.rlp.encode(nestedList)
+    const decoded = src.rlp.decode(encoded)
     assert.deepEqual(nestedList, decoded)
   })
 
@@ -52,24 +52,28 @@ describe('External rlp export', () => {
     // bad values: wrong encoded a zero
     const val = Buffer.from(
       'f9005f030182520894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3',
-      'hex',
+      'hex'
     )
     let result
     try {
       result = src.rlp.decode(val)
-    } catch (e) {}
+    } catch (e) {
+      // pass
+    }
     assert.equal(result, undefined)
 
     // bad values: invalid length
     const a = Buffer.from(
       'f86081000182520894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3',
-      'hex',
+      'hex'
     )
 
     let res
     try {
       result = src.rlp.decode(a)
-    } catch (e) {}
+    } catch (e) {
+      // pass
+    }
     assert.equal(res, undefined)
   })
 })
@@ -90,11 +94,11 @@ describe('External ethjsUtil export', () => {
       'toAscii',
       'getKeys',
       'isHexString',
-      'toUtf8',
+      'toUtf8'
     ]
 
     expected.forEach(prop => {
-      assert.ok(src.hasOwnProperty(prop))
+      assert.ok(prop in src)
     })
   })
 

--- a/test/hash.spec.ts
+++ b/test/hash.spec.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+import assert from 'assert'
 import {
   keccak,
   keccak256,
@@ -12,7 +12,7 @@ import {
   ripemd160FromString,
   ripemd160FromArray,
   rlphash,
-  toBuffer,
+  toBuffer
 } from '../src'
 
 describe('keccak', function() {

--- a/test/object.spec.ts
+++ b/test/object.spec.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+import assert from 'assert'
 import { zeros, defineProperties } from '../src'
 
 describe('define', function() {
@@ -7,33 +7,33 @@ describe('define', function() {
       name: 'aword',
       alias: 'blah',
       word: true,
-      default: Buffer.allocUnsafe(0),
+      default: Buffer.allocUnsafe(0)
     },
     {
       name: 'empty',
       allowZero: true,
       length: 20,
-      default: Buffer.allocUnsafe(0),
+      default: Buffer.allocUnsafe(0)
     },
     {
       name: 'cannotBeZero',
       allowZero: false,
-      default: Buffer.from([0]),
+      default: Buffer.from([0])
     },
     {
       name: 'value',
-      default: Buffer.allocUnsafe(0),
+      default: Buffer.allocUnsafe(0)
     },
     {
       name: 'r',
       length: 32,
       allowLess: true,
-      default: zeros(32),
-    },
+      default: zeros(32)
+    }
   ]
 
   it('should trim zeros', function() {
-    var someOb: any = {}
+    const someOb: any = {}
     defineProperties(someOb, fields)
     // Define Properties
     someOb.r = '0x00004'
@@ -44,7 +44,7 @@ describe('define', function() {
   })
 
   it("shouldn't allow wrong size for exact size requirements", function() {
-    var someOb = {}
+    const someOb = {}
     defineProperties(someOb, fields)
 
     assert.throws(function() {
@@ -53,51 +53,51 @@ describe('define', function() {
           name: 'mustBeExactSize',
           allowZero: false,
           length: 20,
-          default: Buffer.from([1, 2, 3, 4]),
-        },
+          default: Buffer.from([1, 2, 3, 4])
+        }
       ]
       defineProperties(someOb, tmp)
     })
   })
 
   it('it should accept rlp encoded intial data', function() {
-    var someOb: any = {}
-    var data = {
+    const someOb: any = {}
+    const data = {
       aword: '0x01',
       cannotBeZero: '0x02',
       value: '0x03',
-      r: '0x04',
+      r: '0x04'
     }
 
-    var expected = {
+    const expected = {
       aword: '0x01',
       empty: '0x',
       cannotBeZero: '0x02',
       value: '0x03',
-      r: '0x04',
+      r: '0x04'
     }
 
-    var expectedArray = ['0x01', '0x', '0x02', '0x03', '0x04']
+    const expectedArray = ['0x01', '0x', '0x02', '0x03', '0x04']
 
     defineProperties(someOb, fields, data)
     assert.deepEqual(someOb.toJSON(true), expected, 'should produce the correctly labeled object')
 
-    var someOb2: any = {}
-    var rlpEncoded = someOb.serialize().toString('hex')
+    const someOb2: any = {}
+    const rlpEncoded = someOb.serialize().toString('hex')
     defineProperties(someOb2, fields, rlpEncoded)
     assert.equal(
       someOb2.serialize().toString('hex'),
       rlpEncoded,
-      'the constuctor should accept rlp encoded buffers',
+      'the constuctor should accept rlp encoded buffers'
     )
 
-    var someOb3 = {}
+    const someOb3 = {}
     defineProperties(someOb3, fields, expectedArray)
     assert.deepEqual(someOb.toJSON(), expectedArray, 'should produce the correctly object')
   })
 
   it('it should not accept invalid values in the constuctor', function() {
-    var someOb = {}
+    const someOb = {}
     assert.throws(function() {
       defineProperties(someOb, fields, 5)
     }, 'should throw on nonsensical data')
@@ -108,12 +108,12 @@ describe('define', function() {
   })
 
   it('alias should work ', function() {
-    var someOb: any = {}
-    var data = {
+    const someOb: any = {}
+    const data = {
       aword: '0x01',
       cannotBeZero: '0x02',
       value: '0x03',
-      r: '0x04',
+      r: '0x04'
     }
 
     defineProperties(someOb, fields, data)
@@ -124,8 +124,8 @@ describe('define', function() {
   })
 
   it('alias should work #2', function() {
-    var someOb: any = {}
-    var data = { blah: '0x1' }
+    const someOb: any = {}
+    const data = { blah: '0x1' }
 
     defineProperties(someOb, fields, data)
     assert.equal(someOb.blah.toString('hex'), '01')

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert'
-import * as BN from 'bn.js'
+import assert from 'assert'
+import BN from 'bn.js'
 import {
   ecsign,
   ecrecover,
@@ -7,16 +7,16 @@ import {
   hashPersonalMessage,
   isValidSignature,
   fromRpcSig,
-  toRpcSig,
+  toRpcSig
 } from '../src'
 
 const echash = Buffer.from(
   '82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28',
-  'hex',
+  'hex'
 )
 const ecprivkey = Buffer.from(
   '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1',
-  'hex',
+  'hex'
 )
 const chainId = 3 // ropsten
 
@@ -25,11 +25,11 @@ describe('ecsign', function() {
     const sig = ecsign(echash, ecprivkey)
     assert.deepEqual(
       sig.r,
-      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex'),
+      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     )
     assert.deepEqual(
       sig.s,
-      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex'),
+      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     )
     assert.equal(sig.v, 27)
   })
@@ -38,11 +38,11 @@ describe('ecsign', function() {
     const sig = ecsign(echash, ecprivkey, chainId)
     assert.deepEqual(
       sig.r,
-      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex'),
+      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     )
     assert.deepEqual(
       sig.s,
-      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex'),
+      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     )
     assert.equal(sig.v, 41)
   })
@@ -52,11 +52,11 @@ describe('ecsign', function() {
     const sig = ecsign(echash, ecprivkey, chainId)
     assert.deepEqual(
       sig.r,
-      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex'),
+      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     )
     assert.deepEqual(
       sig.s,
-      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex'),
+      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     )
     assert.equal(sig.v, chainId * 2 + 35)
   })
@@ -113,7 +113,7 @@ describe('hashPersonalMessage', function() {
     const h = hashPersonalMessage(Buffer.from('Hello world'))
     assert.deepEqual(
       h,
-      Buffer.from('8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede', 'hex'),
+      Buffer.from('8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede', 'hex')
     )
   })
   it('should throw if input is not a buffer', function() {
@@ -149,7 +149,7 @@ describe('isValidSignature', function() {
   it('should fail when on homestead and s > secp256k1n/2', function() {
     const SECP256K1_N_DIV_2 = new BN(
       '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0',
-      16,
+      16
     )
 
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
@@ -161,7 +161,7 @@ describe('isValidSignature', function() {
   it('should not fail when not on homestead but s > secp256k1n/2', function() {
     const SECP256K1_N_DIV_2 = new BN(
       '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0',
-      16,
+      16
     )
 
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
@@ -199,27 +199,27 @@ describe('message sig', function() {
   it('should return hex strings that the RPC can use', function() {
     assert.equal(
       toRpcSig(27, r, s),
-      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b',
+      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b'
     )
     assert.deepEqual(
       fromRpcSig(
-        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b',
+        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b'
       ),
       {
         v: 27,
         r: r,
-        s: s,
-      },
+        s: s
+      }
     )
     assert.deepEqual(
       fromRpcSig(
-        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca6600',
+        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca6600'
       ),
       {
         v: 27,
         r: r,
-        s: s,
-      },
+        s: s
+      }
     )
   })
 
@@ -228,17 +228,17 @@ describe('message sig', function() {
     const v = chainId * 2 + 35
     assert.equal(
       toRpcSig(v, r, s, chainId),
-      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f',
+      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f'
     )
     assert.deepEqual(
       fromRpcSig(
-        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f',
+        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f'
       ),
       {
         v,
         r: r,
-        s: s,
-      },
+        s: s
+      }
     )
   })
 
@@ -248,7 +248,7 @@ describe('message sig', function() {
     })
     assert.throws(function() {
       fromRpcSig(
-        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca',
+        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca'
       )
     })
   })
@@ -256,7 +256,7 @@ describe('message sig', function() {
   it('pad short r and s values', function() {
     assert.equal(
       toRpcSig(27, r.slice(20), s.slice(20)),
-      '0x00000000000000000000000000000000000000004a1579cf389ef88b20a1abe90000000000000000000000000000000000000000326fa689f228040429e3ca661b',
+      '0x00000000000000000000000000000000000000004a1579cf389ef88b20a1abe90000000000000000000000000000000000000000326fa689f228040429e3ca661b'
     )
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@ethereumjs/config-tsc",
+  "extends": "@ethereumjs/config-typescript",
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
   },
   "include": ["src/**/*.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@ethereumjs/config-tslint"
-}


### PR DESCRIPTION
This PR upgrades this repository to ethereumjs-config v2, switches from coveralls to codecov, and fixes new lint errors. A few functions are moved up in their respective files to satisfy the `no-use-before-define` rule. 

Closes #286.