### PR TITLE
signature/address: support for high recovery and chain IDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
 
       - uses: actions/checkout@v2
       - run: npm install
+
+      - run: npm run lint
       - run: npm run test
 
       - uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:build": "npx typedoc --options typedoc.js",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "test": "npm run lint && npm run test:node && npm run test:browser",
+    "test": "npm run test:node && npm run test:browser",
     "test:browser": "karma start karma.conf.js",
     "test:node": "nyc --reporter=lcov mocha --require ts-node/register 'test/*.spec.ts'",
     "tsc": "ethereumjs-config-tsc"

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,12 +1,12 @@
 import assert from 'assert'
 import BN from 'bn.js'
 import * as rlp from 'rlp'
-import { isHexString, stripHexPrefix } from 'ethjs-util'
+import { stripHexPrefix } from 'ethjs-util'
 import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
 import { zeros, bufferToHex, toBuffer } from './bytes'
 import { keccak, keccak256, keccakFromString, rlphash } from './hash'
 import { assertIsHexString, assertIsBuffer } from './helpers'
-import { BNLike, BufferLike, bnToRlp } from './types'
+import { BNLike, BufferLike, bnToRlp, toType, TypeOutput } from './types'
 
 const {
   privateKeyVerify,
@@ -139,20 +139,12 @@ export const isValidAddress = function(hexAddress: string): boolean {
  */
 export const toChecksumAddress = function(hexAddress: string, eip1191ChainId?: BNLike): string {
   assertIsHexString(hexAddress)
-  if (typeof eip1191ChainId === 'string' && !isHexString(eip1191ChainId)) {
-    throw new Error(`A chainId string must be provided with a 0x-prefix, given: ${eip1191ChainId}`)
-  }
   const address = stripHexPrefix(hexAddress).toLowerCase()
 
   let prefix = ''
   if (eip1191ChainId) {
-    // Performance optimization
-    if (typeof eip1191ChainId === 'number' && Number.isSafeInteger(eip1191ChainId)) {
-      prefix = eip1191ChainId.toString()
-    } else {
-      prefix = new BN(toBuffer(eip1191ChainId)).toString()
-    }
-    prefix += '0x'
+    const chainId = toType(eip1191ChainId, TypeOutput.BN)
+    prefix = chainId.toString() + '0x'
   }
 
   const hash = keccakFromString(prefix + address).toString('hex')

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js'
 import { intToBuffer, stripHexPrefix, padToEven, isHexString, isHexPrefixed } from 'ethjs-util'
-import { TransformableToArray, TransformableToBuffer } from './types'
+import { PrefixedHexString, TransformableToArray, TransformableToBuffer } from './types'
 import { assertIsBuffer, assertIsArray, assertIsHexString } from './helpers'
 
 /**
@@ -112,7 +112,7 @@ export const unpadHexString = function(a: string): string {
  */
 export const toBuffer = function(
   v:
-    | string
+    | PrefixedHexString
     | number
     | BN
     | Buffer

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -105,24 +105,24 @@ export const unpadHexString = function(a: string): string {
   return stripZeros(a) as string
 }
 
+export type ToBufferInputTypes =
+  | PrefixedHexString
+  | number
+  | BN
+  | Buffer
+  | Uint8Array
+  | number[]
+  | TransformableToArray
+  | TransformableToBuffer
+  | null
+  | undefined
+
 /**
  * Attempts to turn a value into a `Buffer`.
  * Inputs supported: `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` or `toBuffer()` method.
  * @param v the value
  */
-export const toBuffer = function(
-  v:
-    | PrefixedHexString
-    | number
-    | BN
-    | Buffer
-    | Uint8Array
-    | number[]
-    | TransformableToArray
-    | TransformableToBuffer
-    | null
-    | undefined
-): Buffer {
+export const toBuffer = function(v: ToBufferInputTypes): Buffer {
   if (v === null || v === undefined) {
     return Buffer.allocUnsafe(0)
   }

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -3,6 +3,7 @@ import BN from 'bn.js'
 import { toBuffer, setLengthLeft, bufferToHex, bufferToInt } from './bytes'
 import { keccak } from './hash'
 import { assertIsBuffer } from './helpers'
+import { BNLike } from './types'
 
 export interface ECDSASignature {
   v: number
@@ -30,7 +31,7 @@ export const ecsign = function(
   return ret
 }
 
-function calculateSigRecovery(v: number | BN | Buffer, chainId?: number | BN | Buffer): BN {
+function calculateSigRecovery(v: BNLike, chainId?: BNLike): BN {
   const vBN = new BN(toBuffer(v))
   const chainIdBN = chainId ? new BN(toBuffer(chainId)) : undefined
   return chainIdBN ? vBN.sub(chainIdBN.muln(2).addn(35)) : vBN.subn(27)
@@ -47,10 +48,10 @@ function isValidSigRecovery(recovery: number | BN): boolean {
  */
 export const ecrecover = function(
   msgHash: Buffer,
-  v: number | BN | Buffer,
+  v: BNLike,
   r: Buffer,
   s: Buffer,
-  chainId?: number | BN | Buffer
+  chainId?: BNLike
 ): Buffer {
   const signature = Buffer.concat([setLengthLeft(r, 32), setLengthLeft(s, 32)], 64)
   const recovery = calculateSigRecovery(v, chainId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,7 @@ export enum TypeOutput {
 }
 
 export type TypeOutputReturnType = {
-  [TypeOutput.Number]: Number
+  [TypeOutput.Number]: number
   [TypeOutput.BN]: BN
   [TypeOutput.Buffer]: Buffer
   [TypeOutput.PrefixedHexString]: PrefixedHexString
@@ -105,7 +105,14 @@ export function toType<T extends TypeOutput>(
   } else if (outputType === TypeOutput.BN) {
     return new BN(input) as any
   } else if (outputType === TypeOutput.Number) {
-    return new BN(input).toNumber() as any
+    const bn = new BN(input)
+    const max = new BN(Number.MAX_SAFE_INTEGER.toString())
+    if (bn.gt(max)) {
+      throw new Error(
+        'The provided number is greater than MAX_SAFE_INTEGER (please use an alternative output type)'
+      )
+    }
+    return bn.toNumber() as any
   } else {
     // outputType === TypeOutput.PrefixedHexString
     return `0x${input.toString('hex')}` as any

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import { unpadBuffer } from './bytes'
 /*
  * A type that represents a BNLike input that can be converted to a BN.
  */
-export type BNLike = BN | string | number
+export type BNLike = BN | PrefixedHexString | number | Buffer
 
 /*
  * A type that represents a BufferLike input that can be converted to a Buffer.
@@ -28,7 +28,7 @@ export type PrefixedHexString = string
  * A type that represents an Address-like value.
  * To convert to address, use `new Address(toBuffer(value))`
  */
-export type AddressLike = Address | Buffer | string
+export type AddressLike = Address | Buffer | PrefixedHexString
 
 /*
  * A type that represents an object that has a `toArray()` method.

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -602,8 +602,26 @@ describe('.toChecksumAddress()', function() {
       for (const [chainId, addresses] of Object.entries(eip1191ChecksummAddresses)) {
         for (const addr of addresses) {
           assert.equal(toChecksumAddress(addr.toLowerCase(), Number(chainId)), addr)
+          assert.equal(toChecksumAddress(addr.toLowerCase(), Buffer.from([chainId])), addr)
+          assert.equal(toChecksumAddress(addr.toLowerCase(), new BN(chainId)), addr)
+          assert.equal(
+            toChecksumAddress(addr.toLowerCase(), '0x' + Buffer.from([chainId]).toString('hex')),
+            addr
+          )
         }
       }
+    })
+    it('Should encode large chain ids greater than MAX_INTEGER correctly', function() {
+      const addr = '0x88021160C5C792225E4E5452585947470010289D'
+      const chainIDBuffer = Buffer.from('796f6c6f763378', 'hex')
+      assert.equal(toChecksumAddress(addr.toLowerCase(), chainIDBuffer), addr)
+      assert.equal(toChecksumAddress(addr.toLowerCase(), new BN(chainIDBuffer)), addr)
+      assert.equal(
+        toChecksumAddress(addr.toLowerCase(), '0x' + chainIDBuffer.toString('hex')),
+        addr
+      )
+      const chainIDNumber = parseInt(chainIDBuffer.toString('hex'), 16)
+      assert.equal(toChecksumAddress(addr.toLowerCase(), chainIDNumber), addr)
     })
   })
 
@@ -611,6 +629,11 @@ describe('.toChecksumAddress()', function() {
     it('Should throw when the address is not hex-prefixed', function() {
       assert.throws(function() {
         toChecksumAddress('52908400098527886E0F7030069857D2E4169EE7'.toLowerCase())
+      })
+    })
+    it('Should throw when the chainId is not hex-prefixed', function() {
+      assert.throws(function() {
+        toChecksumAddress('0xde709f2102306220921060314715629080e2fb77', '1234')
       })
     })
   })
@@ -633,6 +656,12 @@ describe('.isValidChecksumAddress()', function() {
       for (const [chainId, addresses] of Object.entries(eip1191ChecksummAddresses)) {
         for (const addr of addresses) {
           assert.equal(isValidChecksumAddress(addr, Number(chainId)), true)
+          assert.equal(isValidChecksumAddress(addr, Buffer.from([chainId])), true)
+          assert.equal(isValidChecksumAddress(addr, new BN(chainId)), true)
+          assert.equal(
+            isValidChecksumAddress(addr, '0x' + Buffer.from([chainId]).toString('hex')),
+            true
+          )
         }
       }
     })

--- a/test/account.spec.ts
+++ b/test/account.spec.ts
@@ -621,7 +621,15 @@ describe('.toChecksumAddress()', function() {
         addr
       )
       const chainIDNumber = parseInt(chainIDBuffer.toString('hex'), 16)
-      assert.equal(toChecksumAddress(addr.toLowerCase(), chainIDNumber), addr)
+      assert.throws(
+        () => {
+          toChecksumAddress(addr.toLowerCase(), chainIDNumber)
+        },
+        {
+          message:
+            'The provided number is greater than MAX_SAFE_INTEGER (please use an alternative input type)'
+        }
+      )
     })
   })
 

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -48,17 +48,38 @@ describe('ecsign', function() {
   })
 
   it('should produce a signature for chainId=150', function() {
-    const chainId = 150
-    const sig = ecsign(echash, ecprivkey, chainId)
-    assert.deepEqual(
-      sig.r,
-      Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
+    const expectedSigR = Buffer.from(
+      '99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9',
+      'hex'
     )
-    assert.deepEqual(
-      sig.s,
-      Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
+    const expectedSigS = Buffer.from(
+      '129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66',
+      'hex'
     )
-    assert.equal(sig.v, chainId * 2 + 35)
+
+    const sig = ecsign(echash, ecprivkey, 150)
+    assert.deepEqual(sig.r, expectedSigR)
+    assert.deepEqual(sig.s, expectedSigS)
+    assert.equal(sig.v, 150 * 2 + 35)
+
+    const sigBN = ecsign(echash, ecprivkey, new BN(150))
+    assert.deepEqual(sigBN.r, expectedSigR)
+    assert.deepEqual(sigBN.s, expectedSigS)
+    assert.deepEqual(sigBN.v, new BN(150).muln(2).addn(35))
+
+    const sigBuffer = ecsign(echash, ecprivkey, Buffer.from([150]))
+    assert.deepEqual(sigBuffer.r, expectedSigR)
+    assert.deepEqual(sigBuffer.s, expectedSigS)
+    assert.deepEqual(sigBuffer.v, Buffer.from('014f', 'hex'))
+
+    const sigHexString = ecsign(echash, ecprivkey, '0x96')
+    assert.deepEqual(sigHexString.r, expectedSigR)
+    assert.deepEqual(sigHexString.s, expectedSigS)
+    assert.equal(sigHexString.v, '0x14f')
+
+    assert.throws(function() {
+      ecsign(echash, ecprivkey, '96')
+    })
   })
 })
 

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -348,8 +348,8 @@ describe('message sig', function() {
     assert.equal(toRpcSig(27, r, s), sig)
     assert.deepEqual(fromRpcSig(sig), {
       v: 27,
-      r: r,
-      s: s
+      r,
+      s
     })
   })
 
@@ -372,8 +372,8 @@ describe('message sig', function() {
     )
     assert.deepEqual(fromRpcSig(sig), {
       v,
-      r: r,
-      s: s
+      r,
+      s
     })
   })
 

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -106,6 +106,43 @@ describe('ecrecover', function() {
       ecrecover(echash, 27, s, r)
     })
   })
+  it('should return the right sender when using very high chain id / v values', function() {
+    // This data is from a transaction of the YoloV3 network, block 77, txhash c6121a23ca17b8ff70d4706c7d134920c1da43c8329444c96b4c63a55af1c760
+    /*
+      {
+        nonce: '0x8',
+        gasPrice: '0x3b9aca00',
+        gasLimit: '0x1a965',
+        to: undefined,
+        value: '0x0',
+        data: '0x608060405234801561001057600080fd5b50610101806100206000396000f3fe608060405260043610601f5760003560e01c8063776d1a0114603b576020565b5b6000543660008037600080366000845af43d6000803e3d6000f35b348015604657600080fd5b50608660048036036020811015605b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506088565b005b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505056fea26469706673582212206d3160e3f009c6ebac579877e529c0a1ca8313678f08fe311659d440067d26ea64736f6c63430007040033',
+        v: '0xf2ded8deec6714',
+        r: '0xec212841e0b7aaffc3b3e33a08adf32fa07159e856ef23db85175a4f6d71dc0f',
+        s: '0x4b8e02b96b94064a5aa2f8d72bd0040616ba8e482a5dd96422e38c9a4611f8d5'
+      }
+    */
+    const senderPubKey = Buffer.from(
+      '78988201fbceed086cfca7b64e382d08d0bd776898731443d2907c097745b7324c54f522087f5964412cddba019f192de0fd57a0ffa63f098c2b200e53594b15',
+      'hex'
+    )
+    const msgHash = Buffer.from(
+      '8ae8cb685a7a9f29494b07b287c3f6a103b73fa178419d10d1184861a40f6afe',
+      'hex'
+    )
+    const v = Buffer.from('f2ded8deec6714', 'hex')
+    const r = Buffer.from('ec212841e0b7aaffc3b3e33a08adf32fa07159e856ef23db85175a4f6d71dc0f', 'hex')
+    const s = Buffer.from('4b8e02b96b94064a5aa2f8d72bd0040616ba8e482a5dd96422e38c9a4611f8d5', 'hex')
+    const chainID = Buffer.from('796f6c6f763378', 'hex')
+    const sender = ecrecover(msgHash, v, r, s, chainID)
+    assert.ok(sender.equals(senderPubKey), 'sender pubkey correct')
+    const chainIDNumber = parseInt(chainID.toString('hex'), 16)
+    const vNumber = parseInt(v.toString('hex'), 16)
+    assert.throws(() => {
+      // If we would use numbers for the `v` and `chainId` parameters, then it should throw.
+      // (The numbers are too high to perform arithmetic on)
+      ecrecover(msgHash, vNumber, r, s, chainIDNumber)
+    })
+  })
 })
 
 describe('hashPersonalMessage', function() {

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -129,14 +129,27 @@ describe('ecrecover', function() {
       '8ae8cb685a7a9f29494b07b287c3f6a103b73fa178419d10d1184861a40f6afe',
       'hex'
     )
-    const v = Buffer.from('f2ded8deec6714', 'hex')
+
     const r = Buffer.from('ec212841e0b7aaffc3b3e33a08adf32fa07159e856ef23db85175a4f6d71dc0f', 'hex')
     const s = Buffer.from('4b8e02b96b94064a5aa2f8d72bd0040616ba8e482a5dd96422e38c9a4611f8d5', 'hex')
-    const chainID = Buffer.from('796f6c6f763378', 'hex')
-    const sender = ecrecover(msgHash, v, r, s, chainID)
-    assert.ok(sender.equals(senderPubKey), 'sender pubkey correct')
-    const chainIDNumber = parseInt(chainID.toString('hex'), 16)
-    const vNumber = parseInt(v.toString('hex'), 16)
+
+    const vBuffer = Buffer.from('f2ded8deec6714', 'hex')
+    const chainIDBuffer = Buffer.from('796f6c6f763378', 'hex')
+    let sender = ecrecover(msgHash, vBuffer, r, s, chainIDBuffer)
+    assert.ok(sender.equals(senderPubKey), 'sender pubkey correct (Buffer)')
+
+    const vBN = new BN(vBuffer)
+    const chainIDBN = new BN(chainIDBuffer)
+    sender = ecrecover(msgHash, vBN, r, s, chainIDBN)
+    assert.ok(sender.equals(senderPubKey), 'sender pubkey correct (BN)')
+
+    const vHexString = '0xf2ded8deec6714'
+    const chainIDHexString = '0x796f6c6f763378'
+    sender = ecrecover(msgHash, vHexString, r, s, chainIDHexString)
+    assert.ok(sender.equals(senderPubKey), 'sender pubkey correct (HexString)')
+
+    const chainIDNumber = parseInt(chainIDBuffer.toString('hex'), 16)
+    const vNumber = parseInt(vBuffer.toString('hex'), 16)
     assert.throws(() => {
       // If we would use numbers for the `v` and `chainId` parameters, then it should throw.
       // (The numbers are too high to perform arithmetic on)

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -1,0 +1,112 @@
+import assert from 'assert'
+import BN from 'bn.js'
+import { toType, TypeOutput, intToBuffer, bufferToHex, intToHex, bnToHex, toBuffer } from '../src'
+
+describe('toType', function() {
+  describe('from Number', function() {
+    const num = 1000
+    it('should convert to Number', function() {
+      const result = toType(num, TypeOutput.Number)
+      assert.strictEqual(result, num)
+    })
+    it('should convert to BN', function() {
+      const result = toType(num, TypeOutput.BN)
+      assert.ok(result.eq(new BN(num)))
+    })
+    it('should convert to Buffer', function() {
+      const result = toType(num, TypeOutput.Buffer)
+      assert.ok(result.equals(intToBuffer(num)))
+    })
+    it('should convert to PrefixedHexString', function() {
+      const result = toType(num, TypeOutput.PrefixedHexString)
+      assert.strictEqual(result, bufferToHex(new BN(num).toArrayLike(Buffer)))
+    })
+    it('should throw an error if greater than MAX_SAFE_INTEGER', function() {
+      assert.throws(
+        () => {
+          const num = Number.MAX_SAFE_INTEGER + 1
+          toType(num, TypeOutput.BN)
+        },
+        {
+          message:
+            'The provided number is greater than MAX_SAFE_INTEGER (please use an alternative input type)'
+        }
+      )
+    })
+  })
+  describe('from BN', function() {
+    const num = new BN(1000)
+    it('should convert to Number', function() {
+      const result = toType(num, TypeOutput.Number)
+      assert.strictEqual(result, num.toNumber())
+    })
+    it('should convert to BN', function() {
+      const result = toType(num, TypeOutput.BN)
+      assert.ok(result.eq(num))
+    })
+    it('should convert to Buffer', function() {
+      const result = toType(num, TypeOutput.Buffer)
+      assert.ok(result.equals(num.toArrayLike(Buffer)))
+    })
+    it('should convert to PrefixedHexString', function() {
+      const result = toType(num, TypeOutput.PrefixedHexString)
+      assert.strictEqual(result, bufferToHex(num.toArrayLike(Buffer)))
+    })
+    it('should throw an error if converting to Number and greater than MAX_SAFE_INTEGER', function() {
+      const num = new BN(Number.MAX_SAFE_INTEGER).addn(1)
+      assert.throws(
+        () => {
+          toType(num, TypeOutput.Number)
+        },
+        {
+          message:
+            'The provided number is greater than MAX_SAFE_INTEGER (please use an alternative output type)'
+        }
+      )
+    })
+  })
+  describe('from Buffer', function() {
+    const num = intToBuffer(1000)
+    it('should convert to Number', function() {
+      const result = toType(num, TypeOutput.Number)
+      assert.ok(intToBuffer(result).equals(num))
+    })
+    it('should convert to BN', function() {
+      const result = toType(num, TypeOutput.BN)
+      assert.ok(result.eq(new BN(num)))
+    })
+    it('should convert to Buffer', function() {
+      const result = toType(num, TypeOutput.Buffer)
+      assert.ok(result.equals(num))
+    })
+    it('should convert to PrefixedHexString', function() {
+      const result = toType(num, TypeOutput.PrefixedHexString)
+      assert.strictEqual(result, bufferToHex(num))
+    })
+  })
+  describe('from HexPrefixedString', function() {
+    const num = intToHex(1000)
+    it('should convert to Number', function() {
+      const result = toType(num, TypeOutput.Number)
+      assert.strictEqual(intToHex(result), num)
+    })
+    it('should convert to BN', function() {
+      const result = toType(num, TypeOutput.BN)
+      assert.strictEqual(bnToHex(result), num)
+    })
+    it('should convert to Buffer', function() {
+      const result = toType(num, TypeOutput.Buffer)
+      assert.ok(result.equals(toBuffer(num)))
+    })
+    it('should throw an error if is not 0x-prefixed', function() {
+      assert.throws(
+        () => {
+          toType('1', TypeOutput.Number)
+        },
+        {
+          message: 'A string must be provided with a 0x-prefix, given: 1'
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
In https://github.com/ethereumjs/ethereumjs-monorepo/pull/1129 I noticed that `ecrecover` does not have support for very high recovery IDs (which happen on very high chain IDs). This PR allows to pass BNs or Buffers to ecrecover, to allow this support.

I will add a test to show that this works for high chain IDs by taking a YoloV3 transaction.